### PR TITLE
chess: baseline step 0 — README and ROADMAP

### DIFF
--- a/chess/README.md
+++ b/chess/README.md
@@ -1,0 +1,57 @@
+# Chess
+
+A C++ chess engine supporting two-player command-line play. Written originally circa 2012; being modernized as a foundation for new features — specifically, exposing the engine as a tool for LLMs so that a language model can play chess against a human by querying board state and submitting moves.
+
+## Current State
+
+Functional but dated C++ code (pre-C++11 style). Supports:
+
+- Full chess rules: all piece types, en passant, castling, pawn promotion
+- Check, checkmate, and stalemate detection
+- ASCII board display
+- Command-line play with move entry in `a1-b2` format
+- Random move generation (`rand` command)
+
+See [ROADMAP.md](ROADMAP.md) for known issues and the modernization plan.
+
+## Building
+
+No build system is present yet (CMake is coming in Phase 1). Compile directly:
+
+```bash
+g++ -std=c++20 -o chess Main.cpp chess.cpp
+./chess
+```
+
+## Playing
+
+```
+Commands:
+a1-b2       move a piece from a1 to b2
+moves       list all legal moves for the current player
+moves a1    list legal moves for the piece at a1
+rand        make a random legal move
+end         resign
+```
+
+## Coordinate Conventions
+
+The board uses a row/column integer pair internally:
+
+- `x` = row: 0 is white's back rank, 7 is black's back rank
+- `y` = column: 0 is the a-file (queenside), 7 is the h-file (kingside)
+
+Move notation in the command-line interface uses standard algebraic file+rank (`a1`–`h8`), which maps as:
+
+- file (`a`–`h`) → `y` (0–7)
+- rank (`1`–`8`) → `x` (0–7)
+
+## Class Overview
+
+| Class | Responsibility |
+|---|---|
+| `ChessMove` | Encodes a move as a `short int` (packed 3-bit fields). Arrays terminated by `ChessMove::end` (data == 0). |
+| `ChessPiece` | Abstract base for all pieces. Subclasses implement `canMove()` and `getMoves()`. |
+| `Pawn`, `Rook`, `Knight`, `Bishop`, `King`, `Queen` | Concrete piece types with full rule implementations. |
+| `ChessBoard` | Owns the 8×8 grid of piece pointers. Manages piece lifetime. |
+| `ChessGame` | Top-level game controller: turn tracking, move legality, checkmate/stalemate. |

--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -1,0 +1,106 @@
+# Chess Modernization Roadmap
+
+## Goal
+
+Modernize this C++ chess engine to serve as a tool for LLMs. The target end state is a mode where an LLM can play chess against a human: the LLM uses a structured API to query board state, retrieve legal moves, submit moves, and optionally send messages to the human player.
+
+Secondary goals: improved internal board representation, and eventually a traditional minimax/alpha-beta AI opponent.
+
+**Target C++ standard**: C++20
+
+## Current Known Issues
+
+Problems in the existing code that will be addressed during modernization:
+
+### Build / Tooling
+- No build system (no CMake, no Makefile)
+- No tests
+- No CI
+- Windows-specific `system("PAUSE")` calls in `Main.cpp`
+
+### Correctness / Completeness
+- `parseAlgMove()` in `Main.cpp` is an incomplete stub — standard algebraic notation is not fully supported
+- Pawn promotion is handled in `Main.cpp` outside the game logic (not encapsulated)
+- No draw detection: 50-move rule, threefold repetition not implemented
+- No move history / game record
+
+### Design / Style (pre-C++11)
+- `NULL` defined manually in header instead of using `nullptr`
+- Raw owning pointers throughout — no smart pointers, no RAII for pieces
+- Move lists are raw heap-allocated arrays (`new ChessMove[N+1]`), caller-owned, terminated by sentinel
+- C-style headers (`<stdio.h>`, `<string.h>`) instead of `<cstdio>`, `<cstring>`
+- Manual `char` arrays instead of `std::string`
+- Local `int abs(int)` definition in `chess.cpp` shadows / conflicts with `<cstdlib>`
+- No `override` keyword on virtual method overrides
+- Piece position computed by O(64) full-board scan on every call rather than cached
+
+### API / Interfaces
+- Board state exposed only as ASCII art (`toString()`) — no machine-readable format
+- No FEN serialization/deserialization
+- No structured API suitable for external callers (LLMs or otherwise)
+
+---
+
+## Phases
+
+### Phase 0: Baseline *(current)*
+- [x] Write README and ROADMAP
+- Document coordinate conventions and class overview
+- Identify all known issues (above)
+
+### Phase 1: Build System & Compilation
+- Add `CMakeLists.txt` targeting C++20
+- Confirm clean compilation with a modern compiler
+- Fix any errors that prevent compilation
+
+### Phase 2: Testing
+- Add [Catch2 v3](https://github.com/catchorg/Catch2) via CMake `FetchContent`
+- Write unit tests covering core logic:
+  - Move generation for each piece type
+  - Check / checkmate / stalemate detection
+  - En passant and castling
+  - Pawn promotion
+- Target ≥ 80% line coverage on `chess.cpp`
+
+### Phase 3: CI
+- Add GitHub Actions workflow to build and run tests on push and pull request
+
+### Phase 4: Documentation
+- Docstrings on all non-trivial methods
+- Inline comments on non-obvious logic (castling check path, en passant expiry, etc.)
+
+### Phase 5: Code Freshening *(no behavior changes)*
+- `NULL` → `nullptr` throughout
+- C-style headers → C++ equivalents (`<cstdio>`, `<cstring>`, etc.)
+- `char` arrays → `std::string` where straightforward
+- Add `override` to all virtual overrides
+- Remove `system("PAUSE")`; replace with portable alternatives
+- Remove local `abs()` definition; use `<cstdlib>` or `<cmath>`
+- Add `clang-format` config and format all files
+- Add `clang-tidy` to CI
+
+### Phase 6: Architectural Improvements
+- Replace raw owning pointers with `std::unique_ptr<ChessPiece>`
+- Store piece position on the piece (avoid O(64) scan); keep board as secondary index
+- Replace raw move arrays with `std::vector<ChessMove>`
+- Encapsulate pawn promotion within `ChessGame` (remove from `Main.cpp`)
+- Complete algebraic notation parsing
+- Add move history (`std::vector<ChessMove>` in `ChessGame`)
+- Evaluate bitboard representation for move generation (research spike)
+- Add 50-move rule and threefold repetition draw detection
+
+### Phase 7: LLM Tool API
+- FEN serialization and deserialization
+- Structured board state output (JSON or equivalent)
+- Clean public C++ API:
+  - `get_board_fen() -> std::string`
+  - `get_legal_moves() -> std::vector<ChessMove>`
+  - `make_move(from, to) -> Result`
+  - `send_message(text) -> void`
+- Design suitable for subprocess/FFI use or direct embedding
+
+### Phase 8: LLM Player Mode
+- Integration with Anthropic API (Claude as the LLM player)
+- Human vs. LLM game loop
+- LLM receives board state + legal moves; responds with a move and optional message
+- Optional: LLM vs. LLM mode


### PR DESCRIPTION
## Summary

- Adds `chess/README.md`: purpose, build instructions, coordinate conventions, class overview
- Adds `chess/ROADMAP.md`: 8-phase modernization plan + full list of known issues

## Purpose

This is the first PR in a baselining effort for the chess subdirectory. The code is functional but pre-C++11 style and lacks build system, tests, and CI. The end goal is to modernize it into a clean C++20 library that can be exposed as an LLM tool (Claude playing chess against a human via a structured API).

## What's documented

The ROADMAP captures all currently-known issues and lays out phases:
1. Build system (CMake)
2. Tests (Catch2, ≥80% coverage)
3. CI (GitHub Actions)
4. Documentation
5. Code freshening (nullptr, std::string, override, clang-format)
6. Architectural improvements (smart pointers, cached positions, std::vector moves)
7. LLM tool API (FEN, structured board state, move/message interface)
8. LLM player mode (human vs. Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)