### PR TITLE
chess: add CMake build system and Makefile (baseline step 1)

### DIFF
--- a/chess/CMakeLists.txt
+++ b/chess/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(chess VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# chess_lib: the engine logic, usable without the CLI
+add_library(chess_lib STATIC chess.cpp)
+target_include_directories(chess_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(chess_lib PRIVATE -Wall -Wextra -Wpedantic)
+
+# chess: the command-line UI
+add_executable(chess Main.cpp)
+target_link_libraries(chess PRIVATE chess_lib)
+target_compile_options(chess PRIVATE -Wall -Wextra)

--- a/chess/Makefile
+++ b/chess/Makefile
@@ -1,0 +1,16 @@
+BUILD_DIR := build
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(if $(RELEASE),Release,Debug)
+
+.PHONY: all build test clean
+
+all: build
+
+build:
+	cmake -S . -B $(BUILD_DIR) $(CMAKE_FLAGS)
+	cmake --build $(BUILD_DIR)
+
+test: build
+	cd $(BUILD_DIR) && ctest --output-on-failure
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/chess/README.md
+++ b/chess/README.md
@@ -16,11 +16,23 @@ See [ROADMAP.md](ROADMAP.md) for known issues and the modernization plan.
 
 ## Building
 
-No build system is present yet (CMake is coming in Phase 1). Compile directly:
+```bash
+make            # configure and build (debug)
+RELEASE=1 make  # release build
+```
+
+Or using CMake directly:
 
 ```bash
-g++ -std=c++20 -o chess Main.cpp chess.cpp
-./chess
+cmake -S . -B build
+cmake --build build
+./build/chess
+```
+
+Tests (once added in Phase 2):
+
+```bash
+make test
 ```
 
 ## Playing

--- a/chess/README.md
+++ b/chess/README.md
@@ -1,0 +1,57 @@
+# Chess
+
+A C++ chess engine supporting two-player command-line play. Written originally circa 2012; being modernized as a foundation for new features — specifically, exposing the engine as a tool for LLMs so that a language model can play chess against a human by querying board state and submitting moves.
+
+## Current State
+
+Functional but dated C++ code (pre-C++11 style). Supports:
+
+- Full chess rules: all piece types, en passant, castling, pawn promotion
+- Check, checkmate, and stalemate detection
+- ASCII board display
+- Command-line play with move entry in `a1-b2` format
+- Random move generation (`rand` command)
+
+See [ROADMAP.md](ROADMAP.md) for known issues and the modernization plan.
+
+## Building
+
+No build system is present yet (CMake is coming in Phase 1). Compile directly:
+
+```bash
+g++ -std=c++20 -o chess Main.cpp chess.cpp
+./chess
+```
+
+## Playing
+
+```
+Commands:
+a1-b2       move a piece from a1 to b2
+moves       list all legal moves for the current player
+moves a1    list legal moves for the piece at a1
+rand        make a random legal move
+end         resign
+```
+
+## Coordinate Conventions
+
+The board uses a row/column integer pair internally:
+
+- `x` = row: 0 is white's back rank, 7 is black's back rank
+- `y` = column: 0 is the a-file (queenside), 7 is the h-file (kingside)
+
+Move notation in the command-line interface uses standard algebraic file+rank (`a1`–`h8`), which maps as:
+
+- file (`a`–`h`) → `y` (0–7)
+- rank (`1`–`8`) → `x` (0–7)
+
+## Class Overview
+
+| Class | Responsibility |
+|---|---|
+| `ChessMove` | Encodes a move as a `short int` (packed 3-bit fields). Arrays terminated by `ChessMove::end` (data == 0). |
+| `ChessPiece` | Abstract base for all pieces. Subclasses implement `canMove()` and `getMoves()`. |
+| `Pawn`, `Rook`, `Knight`, `Bishop`, `King`, `Queen` | Concrete piece types with full rule implementations. |
+| `ChessBoard` | Owns the 8×8 grid of piece pointers. Manages piece lifetime. |
+| `ChessGame` | Top-level game controller: turn tracking, move legality, checkmate/stalemate. |

--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -48,10 +48,12 @@ Problems in the existing code that will be addressed during modernization:
 - Document coordinate conventions and class overview
 - Identify all known issues (above)
 
-### Phase 1: Build System & Compilation
-- Add `CMakeLists.txt` targeting C++20
-- Confirm clean compilation with a modern compiler
-- Fix any errors that prevent compilation
+### Phase 1: Build System & Compilation *(current)*
+- [x] Add `CMakeLists.txt` targeting C++20 (separates `chess_lib` from CLI)
+- [x] Add convenience `Makefile` wrapping CMake
+- [x] Confirm clean compilation with modern compiler (GCC 15, C++20)
+- [x] Fix initialization-order bug in `ChessGame` (member declaration order matched init list)
+- Remaining `Main.cpp` warnings are from the incomplete `parseAlgMove` stub — tracked for Phase 5/6
 
 ### Phase 2: Testing
 - Add [Catch2 v3](https://github.com/catchorg/Catch2) via CMake `FetchContent`

--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -1,0 +1,106 @@
+# Chess Modernization Roadmap
+
+## Goal
+
+Modernize this C++ chess engine to serve as a tool for LLMs. The target end state is a mode where an LLM can play chess against a human: the LLM uses a structured API to query board state, retrieve legal moves, submit moves, and optionally send messages to the human player.
+
+Secondary goals: improved internal board representation, and eventually a traditional minimax/alpha-beta AI opponent.
+
+**Target C++ standard**: C++20
+
+## Current Known Issues
+
+Problems in the existing code that will be addressed during modernization:
+
+### Build / Tooling
+- No build system (no CMake, no Makefile)
+- No tests
+- No CI
+- Windows-specific `system("PAUSE")` calls in `Main.cpp`
+
+### Correctness / Completeness
+- `parseAlgMove()` in `Main.cpp` is an incomplete stub — standard algebraic notation is not fully supported
+- Pawn promotion is handled in `Main.cpp` outside the game logic (not encapsulated)
+- No draw detection: 50-move rule, threefold repetition not implemented
+- No move history / game record
+
+### Design / Style (pre-C++11)
+- `NULL` defined manually in header instead of using `nullptr`
+- Raw owning pointers throughout — no smart pointers, no RAII for pieces
+- Move lists are raw heap-allocated arrays (`new ChessMove[N+1]`), caller-owned, terminated by sentinel
+- C-style headers (`<stdio.h>`, `<string.h>`) instead of `<cstdio>`, `<cstring>`
+- Manual `char` arrays instead of `std::string`
+- Local `int abs(int)` definition in `chess.cpp` shadows / conflicts with `<cstdlib>`
+- No `override` keyword on virtual method overrides
+- Piece position computed by O(64) full-board scan on every call rather than cached
+
+### API / Interfaces
+- Board state exposed only as ASCII art (`toString()`) — no machine-readable format
+- No FEN serialization/deserialization
+- No structured API suitable for external callers (LLMs or otherwise)
+
+---
+
+## Phases
+
+### Phase 0: Baseline *(current)*
+- [x] Write README and ROADMAP
+- Document coordinate conventions and class overview
+- Identify all known issues (above)
+
+### Phase 1: Build System & Compilation
+- Add `CMakeLists.txt` targeting C++20
+- Confirm clean compilation with a modern compiler
+- Fix any errors that prevent compilation
+
+### Phase 2: Testing
+- Add [Catch2 v3](https://github.com/catchorg/Catch2) via CMake `FetchContent`
+- Write unit tests covering core logic:
+  - Move generation for each piece type
+  - Check / checkmate / stalemate detection
+  - En passant and castling
+  - Pawn promotion
+- Target ≥ 80% line coverage on `chess.cpp`
+
+### Phase 3: CI
+- Add GitHub Actions workflow to build and run tests on push and pull request
+
+### Phase 4: Documentation
+- Docstrings on all non-trivial methods
+- Inline comments on non-obvious logic (castling check path, en passant expiry, etc.)
+
+### Phase 5: Code Freshening *(no behavior changes)*
+- `NULL` → `nullptr` throughout
+- C-style headers → C++ equivalents (`<cstdio>`, `<cstring>`, etc.)
+- `char` arrays → `std::string` where straightforward
+- Add `override` to all virtual overrides
+- Remove `system("PAUSE")`; replace with portable alternatives
+- Remove local `abs()` definition; use `<cstdlib>` or `<cmath>`
+- Add `clang-format` config and format all files
+- Add `clang-tidy` to CI
+
+### Phase 6: Architectural Improvements
+- Replace raw owning pointers with `std::unique_ptr<ChessPiece>`
+- Store piece position on the piece (avoid O(64) scan); keep board as secondary index
+- Replace raw move arrays with `std::vector<ChessMove>`
+- Encapsulate pawn promotion within `ChessGame` (remove from `Main.cpp`)
+- Complete algebraic notation parsing
+- Add move history (`std::vector<ChessMove>` in `ChessGame`)
+- Evaluate bitboard representation for move generation (research spike)
+- Add 50-move rule and threefold repetition draw detection
+
+### Phase 7: LLM Tool API
+- FEN serialization and deserialization
+- Structured board state output (JSON or equivalent)
+- Clean public C++ API:
+  - `get_board_fen() -> std::string`
+  - `get_legal_moves() -> std::vector<ChessMove>`
+  - `make_move(from, to) -> Result`
+  - `send_message(text) -> void`
+- Design suitable for subprocess/FFI use or direct embedding
+
+### Phase 8: LLM Player Mode
+- Integration with Anthropic API (Claude as the LLM player)
+- Human vs. LLM game loop
+- LLM receives board state + legal moves; responds with a move and optional message
+- Optional: LLM vs. LLM mode

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -242,8 +242,8 @@ class ChessGame
     ChessBoard * getPieceBoard();
  private:
     bool rulesOn;
-    ChessBoard board;
     bool whiteTurn;
+    ChessBoard board;
 };
 
 #endif //def _CHESS_H


### PR DESCRIPTION
## Summary

- Adds `CMakeLists.txt` (C++20): separates `chess_lib` (engine only) from `chess` (CLI), making the library independently linkable for tests and future tool API
- Adds `Makefile` convenience wrapper: `make`, `make test`, `make clean`
- Fixes initialization-order bug in `ChessGame`: private member declaration order now matches the constructor initializer list
- Updates `README.md` with CMake/make build instructions
- Updates `ROADMAP.md` to mark Phase 1 complete

## Compilation status

Builds cleanly under GCC 15 / C++20. Remaining warnings are all in `Main.cpp` (incomplete `parseAlgMove` stub, `system("PAUSE")`, unchecked return values) — pre-existing, tracked in ROADMAP for Phases 5–6.

## Depends on

PR #3 (baseline step 0: README and ROADMAP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)