### PR TITLE
chess: add GitHub Actions CI (baseline step 3)

### DIFF
--- a/.github/workflows/chess-ci.yml
+++ b/.github/workflows/chess-ci.yml
@@ -1,0 +1,71 @@
+name: Chess CI
+
+on:
+  push:
+    branches: [master]
+    paths: ["chess/**", ".github/workflows/chess-ci.yml"]
+  pull_request:
+    branches: [master]
+    paths: ["chess/**", ".github/workflows/chess-ci.yml"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get install -y cmake g++ lcov
+
+      - name: Cache Catch2
+        uses: actions/cache@v4
+        with:
+          path: chess/build/_deps
+          key: catch2-${{ hashFiles('chess/CMakeLists.txt') }}
+
+      - name: Configure (Debug)
+        run: cmake -S chess -B chess/build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build chess/build --parallel
+
+      - name: Test
+        run: cd chess/build && ctest --output-on-failure
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get install -y cmake g++ lcov
+
+      - name: Cache Catch2
+        uses: actions/cache@v4
+        with:
+          path: chess/build-cov/_deps
+          key: catch2-cov-${{ hashFiles('chess/CMakeLists.txt') }}
+
+      - name: Configure with coverage
+        run: cmake -S chess -B chess/build-cov -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+
+      - name: Build
+        run: cmake --build chess/build-cov --parallel
+
+      - name: Test
+        run: cd chess/build-cov && ctest --output-on-failure
+
+      - name: Generate coverage report
+        run: |
+          lcov --capture --directory chess/build-cov --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/Catch2/*' --output-file coverage_filtered.info
+          lcov --list coverage_filtered.info
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage_filtered.info


### PR DESCRIPTION
## Summary

Adds `.github/workflows/chess-ci.yml` with two jobs:

| Job | What it does |
|---|---|
| `build-and-test` | Configure (Debug), build, run all 63 Catch2 tests |
| `coverage` | Build with `--coverage`, generate lcov report, upload as artifact |

Both jobs cache the Catch2 FetchContent download (keyed on `CMakeLists.txt`) to avoid re-fetching on every run.

## Trigger

Runs on push/PR to `master` when `chess/**` or the workflow file itself changes. Other subdirectories in the repo do not trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)