### PR TITLE
chess: add documentation (baseline step 4)

### DIFF
--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -67,8 +67,8 @@ Problems in the existing code that will be addressed during modernization:
 - Add GitHub Actions workflow to build and run tests on push and pull request
 
 ### Phase 4: Documentation
-- Docstrings on all non-trivial methods
-- Inline comments on non-obvious logic (castling check path, en passant expiry, etc.)
+- [x] Docstrings on all non-trivial methods
+- [x] Inline comments on non-obvious logic (castling check path, en passant expiry, chkchk mutation pattern, coordinate convention, magic numbers in toString)
 
 ### Phase 5: Code Freshening *(no behavior changes)*
 - `NULL` → `nullptr` throughout


### PR DESCRIPTION
## Summary

Phase 4 of the chess modernization roadmap: documentation pass over `chess.h` and `chess.cpp`.

**chess.h** — class-level and method-level doc comments:
- Board coordinate convention (`x`=row, `y`=column, `x=0` is white back rank)
- `ChessMove`: packed `short int` encoding, end-sentinel pattern, caller-owned arrays
- `ChessPiece`: O(64) position scan, friend-accessor workaround, `canMove`/`getMoves` contracts
- `ChessBoard::checkCheck`: error-sentinel return when king not found
- `ChessGame`: why promotion lives in `Main.cpp`

**chess.cpp** — inline comments on non-obvious logic:
- `Pawn::canMove`: double-advance target rows, en passant eligibility rows
- `canMove` `chkchk` pattern: board mutation/restoration for self-check detection (explained once fully in `Pawn::canMove`, referenced briefly in others)
- `King::canMove` castling: hard-coded `y=4`, sign formula for rook column, intermediate-square check stepping
- `King::inCheck`: why `canMove(..., false)` is used (avoid recursion)
- `ChessBoard::toString`: magic numbers (`42 * 33 + 1 = 1387`)
- `ChessGame::makeMove`: en passant expiry timing relative to the turn flip

No behavior changes. All 63 tests pass.

## Test plan
- [ ] CI passes (build + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)