### PR TITLE
chess: code freshening (baseline step 5)

### DIFF
--- a/.github/workflows/chess-ci.yml
+++ b/.github/workflows/chess-ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y cmake g++ lcov
+        run: sudo apt-get install -y cmake g++ lcov clang-tidy
 
       - name: Cache Catch2
         uses: actions/cache@v4
@@ -32,6 +32,9 @@ jobs:
 
       - name: Test
         run: cd chess/build && ctest --output-on-failure
+
+      - name: clang-tidy
+        run: clang-tidy chess/chess.cpp chess/Main.cpp -p chess/build --warnings-as-errors='*'
 
   coverage:
     runs-on: ubuntu-latest

--- a/chess/.clang-format
+++ b/chess/.clang-format
@@ -1,0 +1,7 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+PointerAlignment: Left
+DerivePointerAlignment: false

--- a/chess/.clang-tidy
+++ b/chess/.clang-tidy
@@ -1,0 +1,11 @@
+---
+Checks: >
+  -*,
+  modernize-use-nullptr,
+  modernize-use-override,
+  clang-analyzer-core.NullDereference,
+  clang-analyzer-cplusplus.NewDelete,
+  clang-analyzer-cplusplus.NewDeleteLeaks
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*chess.*'
+FormatStyle: file

--- a/chess/CMakeLists.txt
+++ b/chess/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Export compile_commands.json for clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # chess_lib: the engine logic, usable without the CLI
 add_library(chess_lib STATIC chess.cpp)
 target_include_directories(chess_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -10,7 +10,7 @@
 
 void printDelete(char* sz);
 void printMoves(bool color, const ChessGame& game);
-void printMoveList(const ChessMove* paMoves);
+void printMoveList(const ChessMove* moves);
 // TODO: complete algebraic notation parsing (Phase 6)
 // ChessMove parseAlgMove( const char * szMove, const ChessBoard & board );
 // int stdMoves( const char * szMove, const ChessBoard & board );
@@ -19,7 +19,7 @@ int main(int argc, char* argv[]) {
     srand(time(nullptr));  // initialize random number generator
     bool print = true;
     ChessGame game = ChessGame();
-    std::string szInput;
+    std::string input;
 
     int blackProms = 0;  // promotions
     int whiteProms = 0;
@@ -52,9 +52,9 @@ int main(int argc, char* argv[]) {
                 print = false;
             }
         }
-        if (!std::getline(std::cin, szInput)) break;
+        if (!std::getline(std::cin, input)) break;
 
-        if (szInput == "end") {
+        if (input == "end") {
             if (game.getTurn())
                 printf("\nWhite resigns.\n\n");
             else
@@ -63,33 +63,32 @@ int main(int argc, char* argv[]) {
             return 0;
         }
 
-        if (szInput == "moves") {
+        if (input == "moves") {
             printMoves(game.getTurn(), game);
             printf("\n");
-        } else if (szInput.substr(0, 6) == "moves ") {
-            int x = szInput[7] - '1';
-            int y = szInput[6] - 'a';
+        } else if (input.substr(0, 6) == "moves ") {
+            int x = input[7] - '1';
+            int y = input[6] - 'a';
             if (game.getPiece(x, y) != nullptr) {
-                ChessMove* paMoves = game.getPiece(x, y)->getMoves();
-                printMoveList(paMoves);
+                ChessMove* moves = game.getPiece(x, y)->getMoves();
+                printMoveList(moves);
                 printf("\n");
-                delete[] paMoves;
+                delete[] moves;
             }
-        } else if (szInput == "rand") {
-            ChessMove* paMoves = game.getMoves(game.getTurn());
-            int l = ChessMove::length(paMoves);
+        } else if (input == "rand") {
+            ChessMove* moves = game.getMoves(game.getTurn());
+            int l = ChessMove::length(moves);
             int move;
             if (l != 0) {
                 move = rand() % l;
-                game.makeMove(paMoves[move]);
+                game.makeMove(moves[move]);
                 print = true;
-                if ((paMoves[move].getEndX() == 0 ||
-                     paMoves[move].getEndX() == 7) &&  // pawn promotion
-                    game.getPiece(paMoves[move].getEndX(), paMoves[move].getEndY())->getType() ==
+                if ((moves[move].getEndX() == 0 || moves[move].getEndX() == 7) &&  // pawn promotion
+                    game.getPiece(moves[move].getEndX(), moves[move].getEndY())->getType() ==
                         PAWN) {
                     ChessPiece* piece = nullptr;
-                    bool KingSide = false;
-                    if (paMoves[move].getEndY() > 3) KingSide = true;
+                    bool kingSide = false;
+                    if (moves[move].getEndY() > 3) kingSide = true;
 
                     int index = 0;
                     if (game.getTurn()) {
@@ -100,23 +99,23 @@ int main(int argc, char* argv[]) {
                         whiteProms++;
                     }
 
-                    piece = new Queen(!game.getTurn(), game.getPieceBoard(), index, KingSide);
+                    piece = new Queen(!game.getTurn(), game.getPieceBoard(), index, kingSide);
                     game.setRules(false);
-                    game.setPiece(paMoves[move].getEndX(), paMoves[move].getEndY(), piece);
+                    game.setPiece(moves[move].getEndX(), moves[move].getEndY(), piece);
                     game.setRules(true);
                 }
             }
-            delete[] paMoves;
+            delete[] moves;
         } else {
-            ChessMove move = ChessMove(szInput.c_str());
+            ChessMove move = ChessMove(input.c_str());
             if (game.makeMove(move)) {
                 print = true;
                 if ((move.getEndX() == 0 || move.getEndX() == 7) &&
                     game.getPiece(move.getEndX(), move.getEndY())->getType() == PAWN) {
                     char pieceType = '\0';
                     ChessPiece* piece = nullptr;
-                    bool KingSide = false;
-                    if (move.getEndY() > 3) KingSide = true;
+                    bool kingSide = false;
+                    if (move.getEndY() > 3) kingSide = true;
 
                     int index = 0;
                     if (game.getTurn()) {
@@ -134,26 +133,26 @@ int main(int argc, char* argv[]) {
                         case 'R':
                         case 'r': {
                             piece =
-                                new Rook(!game.getTurn(), KingSide, game.getPieceBoard(), index);
+                                new Rook(!game.getTurn(), kingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'N':
                         case 'n': {
                             piece =
-                                new Knight(!game.getTurn(), KingSide, game.getPieceBoard(), index);
+                                new Knight(!game.getTurn(), kingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'B':
                         case 'b': {
                             piece =
-                                new Bishop(!game.getTurn(), KingSide, game.getPieceBoard(), index);
+                                new Bishop(!game.getTurn(), kingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'Q':
                         case 'q':
                         default: {
                             piece =
-                                new Queen(!game.getTurn(), game.getPieceBoard(), index, KingSide);
+                                new Queen(!game.getTurn(), game.getPieceBoard(), index, kingSide);
                             break;
                         }
                     }
@@ -179,10 +178,10 @@ void printMoves(bool color, const ChessGame& game) {
     delete[] moves;
 }
 
-void printMoveList(const ChessMove* paMoves) {
-    int l = ChessMove::length(paMoves);
+void printMoveList(const ChessMove* moves) {
+    int l = ChessMove::length(moves);
     for (int i = 0; i < l; i++) {
-        printf("%s\n", paMoves[i].toString());
+        printf("%s\n", moves[i].toString());
     }
 }
 

--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -1,209 +1,188 @@
 // This is the Main.cpp  file which holds the main() funcion.
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "chess.h"
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <string>
 
-void printDelete( char * sz );
-void printMoves( bool color, const ChessGame & game );
-void printMoveList( const ChessMove * paMoves );
+#include "chess.h"
+
+void printDelete(char* sz);
+void printMoves(bool color, const ChessGame& game);
+void printMoveList(const ChessMove* paMoves);
 // TODO: complete algebraic notation parsing (Phase 6)
 // ChessMove parseAlgMove( const char * szMove, const ChessBoard & board );
 // int stdMoves( const char * szMove, const ChessBoard & board );
 
-int main( int argc, char * argv[] )
-{
-    srand( time( NULL ) );          // initialize random number generator
+int main(int argc, char* argv[]) {
+    srand(time(nullptr));  // initialize random number generator
     bool print = true;
     ChessGame game = ChessGame();
-    char szInput[128];
-    szInput[0] = '\0';
-    
-    int blackProms = 0;             // promotions
+    std::string szInput;
+
+    int blackProms = 0;  // promotions
     int whiteProms = 0;
-    
+
     printf("Chess Version 1.0\n\n");
-    printf("Commands:\nx#-x#\t\tmove\nend\t\texit\nmoves\t\tshow moves\nmoves x#\tshow moves at x#\n");
+    printf(
+        "Commands:\nx#-x#\t\tmove\nend\t\texit\nmoves\t\tshow moves\nmoves x#\tshow moves at x#\n");
     printf("rand\t\tmake a random move\n\n");
-    
-    while( true )
-    {
-        if ( print )
-        {
-            printf( "%s\n\n", game.getBoard() );
-            if ( game.checkmate( game.getTurn() ) )
-            {
-                printf( "Checkmate! " );
-                if ( game.getTurn() )
-                    printf( "Black" );
+
+    while (true) {
+        if (print) {
+            printf("%s\n\n", game.getBoard());
+            if (game.checkmate(game.getTurn())) {
+                printf("Checkmate! ");
+                if (game.getTurn())
+                    printf("Black");
                 else
-                    printf( "White" );
-                printf( " wins!\n" );
-                system( "PAUSE" );
+                    printf("White");
+                printf(" wins!\n");
                 return 0;
-            } else if ( game.stalemate( game.getTurn() ) ) {
-                printf( "Game Over! Stalemate.\n" );
-                system( "PAUSE" );
+            } else if (game.stalemate(game.getTurn())) {
+                printf("Game Over! Stalemate.\n");
                 return 0;
             } else {
-                printf( "Enter move for " );
-                if ( game.getTurn() )
-                    printf( "white:\n" );
+                printf("Enter move for ");
+                if (game.getTurn())
+                    printf("white:\n");
                 else
-                    printf( "black:\n" );
+                    printf("black:\n");
                 print = false;
             }
         }
-        szInput[0] = szInput[1] = szInput[2] = szInput[3] = szInput[4] = szInput[5] = '\0';
-        fgets( szInput, 128, stdin );
-        
-        szInput[strlen( szInput ) - 1] = '\0';
-        
-        if ( strcmp( szInput, "end" ) == 0 )
-        {
-            if ( game.getTurn() )
-                printf( "\nWhite resigns.\n\n" );
+        if (!std::getline(std::cin, szInput)) break;
+
+        if (szInput == "end") {
+            if (game.getTurn())
+                printf("\nWhite resigns.\n\n");
             else
-                printf( "\nBlack resigns.\n\n" );
-            
-            system( "PAUSE" );
+                printf("\nBlack resigns.\n\n");
+
             return 0;
         }
-        
-        if ( strcmp( szInput, "moves" ) == 0 )
-        {
-            printMoves( game.getTurn(), game );
-            printf( "\n" );
-        } else if ( strncmp( szInput, "moves ", 6 ) == 0 ) {
+
+        if (szInput == "moves") {
+            printMoves(game.getTurn(), game);
+            printf("\n");
+        } else if (szInput.substr(0, 6) == "moves ") {
             int x = szInput[7] - '1';
             int y = szInput[6] - 'a';
-            if ( game.getPiece( x, y ) != NULL )
-            {
-                ChessMove * paMoves = game.getPiece( x, y )->getMoves();
-                printMoveList( paMoves );
-                printf( "\n" );
+            if (game.getPiece(x, y) != nullptr) {
+                ChessMove* paMoves = game.getPiece(x, y)->getMoves();
+                printMoveList(paMoves);
+                printf("\n");
                 delete[] paMoves;
             }
-        } else if ( strcmp( szInput, "rand" ) == 0 ) {
-            ChessMove * paMoves = game.getMoves( game.getTurn() );
-            int l = ChessMove::length( paMoves );
+        } else if (szInput == "rand") {
+            ChessMove* paMoves = game.getMoves(game.getTurn());
+            int l = ChessMove::length(paMoves);
             int move;
-            if ( l != 0 )
-            {
+            if (l != 0) {
                 move = rand() % l;
-                game.makeMove( paMoves[move] );
+                game.makeMove(paMoves[move]);
                 print = true;
-                if ( ( paMoves[move].getEndX() == 0  ||  paMoves[move].getEndX() == 7 ) &&          // pawn promotion
-                       game.getPiece( paMoves[move].getEndX(), paMoves[move].getEndY() )->getType() == PAWN )
-                {
-                    ChessPiece * piece = NULL;
+                if ((paMoves[move].getEndX() == 0 ||
+                     paMoves[move].getEndX() == 7) &&  // pawn promotion
+                    game.getPiece(paMoves[move].getEndX(), paMoves[move].getEndY())->getType() ==
+                        PAWN) {
+                    ChessPiece* piece = nullptr;
                     bool KingSide = false;
-                    if ( paMoves[move].getEndY() > 3 )
-                        KingSide = true;
-                    
+                    if (paMoves[move].getEndY() > 3) KingSide = true;
+
                     int index = 0;
-                    if ( game.getTurn() )
-                    {
+                    if (game.getTurn()) {
                         index = blackProms;
                         blackProms++;
                     } else {
                         index = whiteProms;
                         whiteProms++;
                     }
-                    
-                    piece = new Queen( !game.getTurn(), game.getPieceBoard(), index, KingSide );
-                    game.setRules( false );
-                    game.setPiece( paMoves[move].getEndX(), paMoves[move].getEndY(), piece );
-                    game.setRules( true );
+
+                    piece = new Queen(!game.getTurn(), game.getPieceBoard(), index, KingSide);
+                    game.setRules(false);
+                    game.setPiece(paMoves[move].getEndX(), paMoves[move].getEndY(), piece);
+                    game.setRules(true);
                 }
             }
             delete[] paMoves;
         } else {
-            ChessMove move = ChessMove( szInput );
-            if ( game.makeMove( move ) )
-            {
+            ChessMove move = ChessMove(szInput.c_str());
+            if (game.makeMove(move)) {
                 print = true;
-                if ( ( move.getEndX() == 0  ||  move.getEndX() == 7 ) &&  game.getPiece( move.getEndX(), move.getEndY() )->getType() == PAWN )
-                {
+                if ((move.getEndX() == 0 || move.getEndX() == 7) &&
+                    game.getPiece(move.getEndX(), move.getEndY())->getType() == PAWN) {
                     char pieceType = '\0';
-                    ChessPiece * piece = NULL;
+                    ChessPiece* piece = nullptr;
                     bool KingSide = false;
-                    if ( move.getEndY() > 3 )
-                        KingSide = true;
-                    
+                    if (move.getEndY() > 3) KingSide = true;
+
                     int index = 0;
-                    if ( game.getTurn() )
-                    {
+                    if (game.getTurn()) {
                         index = blackProms;
                         blackProms++;
                     } else {
                         index = whiteProms;
                         whiteProms++;
                     }
-                    
-                    printf( "You have moved a pawn to the end of the board!\n" );
-                    printf( "What do you want to promote it to? (Q, R, N, B)\n" );
-                    scanf( "%c", &pieceType );
-                    switch( pieceType )
-                    {
+
+                    printf("You have moved a pawn to the end of the board!\n");
+                    printf("What do you want to promote it to? (Q, R, N, B)\n");
+                    scanf("%c", &pieceType);
+                    switch (pieceType) {
                         case 'R':
-                        case 'r':
-                        {
-                            piece = new Rook( !game.getTurn(), KingSide, game.getPieceBoard(), index );
+                        case 'r': {
+                            piece =
+                                new Rook(!game.getTurn(), KingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'N':
-                        case 'n':
-                        {
-                            piece = new Knight( !game.getTurn(), KingSide, game.getPieceBoard(), index );
+                        case 'n': {
+                            piece =
+                                new Knight(!game.getTurn(), KingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'B':
-                        case 'b':
-                        {
-                            piece = new Bishop( !game.getTurn(), KingSide, game.getPieceBoard(), index );
+                        case 'b': {
+                            piece =
+                                new Bishop(!game.getTurn(), KingSide, game.getPieceBoard(), index);
                             break;
                         }
                         case 'Q':
                         case 'q':
-                        default:
-                        {
-                            piece = new Queen( !game.getTurn(), game.getPieceBoard(), index, KingSide );
+                        default: {
+                            piece =
+                                new Queen(!game.getTurn(), game.getPieceBoard(), index, KingSide);
                             break;
                         }
                     }
-                    game.setRules( false );
-                    game.setPiece( move.getEndX(), move.getEndY(), piece );
-                    game.setRules( true );
+                    game.setRules(false);
+                    game.setPiece(move.getEndX(), move.getEndY(), piece);
+                    game.setRules(true);
                 }
             }
         }
     }
-    
+
     return 0;
 }
 
-void printDelete( char * sz )
-{
-    printf( "%s", sz );
+void printDelete(char* sz) {
+    printf("%s", sz);
     delete[] sz;
 }
 
-void printMoves( bool color, const ChessGame & game )
-{
-    ChessMove * moves = game.getMoves( color );
-    printMoveList( moves );
+void printMoves(bool color, const ChessGame& game) {
+    ChessMove* moves = game.getMoves(color);
+    printMoveList(moves);
     delete[] moves;
 }
 
-void printMoveList( const ChessMove * paMoves )
-{
-    int l = ChessMove::length( paMoves );
-    for( int i = 0; i < l; i++ )
-    {
-        printf( "%s\n", paMoves[i].toString() );
+void printMoveList(const ChessMove* paMoves) {
+    int l = ChessMove::length(paMoves);
+    for (int i = 0; i < l; i++) {
+        printf("%s\n", paMoves[i].toString());
     }
 }
 

--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -71,14 +71,14 @@ Problems in the existing code that will be addressed during modernization:
 - [x] Inline comments on non-obvious logic (castling check path, en passant expiry, chkchk mutation pattern, coordinate convention, magic numbers in toString)
 
 ### Phase 5: Code Freshening *(no behavior changes)*
-- `NULL` → `nullptr` throughout
-- C-style headers → C++ equivalents (`<cstdio>`, `<cstring>`, etc.)
-- `char` arrays → `std::string` where straightforward
-- Add `override` to all virtual overrides
-- Remove `system("PAUSE")`; replace with portable alternatives
-- Remove local `abs()` definition; use `<cstdlib>` or `<cmath>`
-- Add `clang-format` config and format all files
-- Add `clang-tidy` to CI
+- [x] `NULL` → `nullptr` throughout
+- [x] C-style headers → C++ equivalents (`<cstdio>`, `<cstring>`, `<ctime>`, `<iostream>`, `<string>`)
+- [x] `char` arrays → `std::string` where straightforward (`ChessBoard::szForm`, `Main.cpp` input)
+- [x] Add `override` to all virtual overrides (including destructors)
+- [x] Remove `system("PAUSE")`
+- [x] Remove local `abs()` definition; use `std::abs` from `<cstdlib>`
+- [x] Add `.clang-format` config (Google-based, 4-space indent) and format all files
+- [x] Add `.clang-tidy` config and clang-tidy step to CI
 
 ### Phase 6: Architectural Improvements
 - Replace raw owning pointers with `std::unique_ptr<ChessPiece>`

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -9,40 +9,39 @@ using std::abs;
 ///////////
 // CHESSMOVE
 const ChessMove ChessMove::end = ChessMove();
-const char ChessMove::szlcLetters[8 + 1] = "abcdefgh";
-const int ChessMove::MAXCMLENGTH =
-    1024;  // 669 should be sufficient for all moves of both sides, FYI
+const char ChessMove::fileLetters[8 + 1] = "abcdefgh";
+const int ChessMove::maxLength = 1024;  // 669 should be sufficient for all moves of both sides, FYI
 
 ChessMove::ChessMove() : data(0) {
-    szForm[3] = '\0';
-    szForm[0] = 'E';
-    szForm[1] = 'N';
-    szForm[2] = 'D';
-    szForm[4] = '\0';
-    szForm[5] = '\0';
+    repr[3] = '\0';
+    repr[0] = 'E';
+    repr[1] = 'N';
+    repr[2] = 'D';
+    repr[4] = '\0';
+    repr[5] = '\0';
 }
 
 ChessMove::ChessMove(int sX, int sY, int eX, int eY) : data(0) { init(sX, sY, eX, eY); }
 
-ChessMove::ChessMove(const char* const pszMove) : data(0) {
-    int sY = (int)(pszMove[0] - 'a');
-    int sX = (int)(pszMove[1] - '1');
+ChessMove::ChessMove(const char* const str) : data(0) {
+    int sY = (int)(str[0] - 'a');
+    int sX = (int)(str[1] - '1');
 
     int eX, eY;
 
-    if (pszMove[2] == ' ' || pszMove[2] == '-') {
-        eY = (int)(pszMove[3] - 'a');
-        eX = (int)(pszMove[4] - '1');
+    if (str[2] == ' ' || str[2] == '-') {
+        eY = (int)(str[3] - 'a');
+        eX = (int)(str[4] - '1');
     } else {
-        eY = (int)(pszMove[2] - 'a');
-        eX = (int)(pszMove[3] - '1');
+        eY = (int)(str[2] - 'a');
+        eX = (int)(str[3] - '1');
     }
     init(sX, sY, eX, eY);
 }
 
 ChessMove::ChessMove(const ChessMove& rcm) : data(rcm.data) {
     for (int i = 0; i < 6; i++) {
-        szForm[i] = rcm.szForm[i];
+        repr[i] = rcm.repr[i];
     }
 }
 
@@ -53,7 +52,7 @@ ChessMove& ChessMove::operator=(const ChessMove& rhs) {
 
     data = rhs.data;
     for (int i = 0; i < 6; i++) {
-        szForm[i] = rhs.szForm[i];
+        repr[i] = rhs.repr[i];
     }
     return *this;
 }
@@ -90,7 +89,7 @@ void ChessMove::sort(ChessMove* acm, int size) {
 int ChessMove::length(ChessMove const* cm) {
     if (cm == nullptr) return 0;
     int l;
-    for (l = 0; !(cm[l].isEnd()) && l < MAXCMLENGTH; l++);
+    for (l = 0; !(cm[l].isEnd()) && l < maxLength; l++);
     return l;
 }
 
@@ -106,7 +105,7 @@ void ChessMove::concat(ChessMove* cm1, const ChessMove* cm2) {
     if (cm1[l].isEnd()) copy(cm1 + l, cm2);
 }
 
-const char* ChessMove::toString() const { return szForm; }
+const char* ChessMove::toString() const { return repr; }
 
 void ChessMove::init(int sX, int sY, int eX, int eY) {
     if (sX < 0 || sX > 7 || sY < 0 || sY > 7 || eX < 0 || eX > 7 || eY < 0 || eY > 7)
@@ -123,43 +122,43 @@ void ChessMove::init(int sX, int sY, int eX, int eY) {
     }
 
     if (!isEnd()) {
-        szForm[5] = '\0';
-        szForm[2] = '-';
-        szForm[0] = szlcLetters[getStartY()];
-        szForm[1] = ChessPiece::szDigits[getStartX() + 1];
-        szForm[3] = szlcLetters[getEndY()];
-        szForm[4] = ChessPiece::szDigits[getEndX() + 1];
+        repr[5] = '\0';
+        repr[2] = '-';
+        repr[0] = fileLetters[getStartY()];
+        repr[1] = ChessPiece::digits[getStartX() + 1];
+        repr[3] = fileLetters[getEndY()];
+        repr[4] = ChessPiece::digits[getEndX() + 1];
     } else {
-        szForm[3] = '\0';
-        szForm[0] = 'E';
-        szForm[1] = 'N';
-        szForm[2] = 'D';
-        szForm[4] = '\0';
-        szForm[5] = '\0';
+        repr[3] = '\0';
+        repr[0] = 'E';
+        repr[1] = 'N';
+        repr[2] = 'D';
+        repr[4] = '\0';
+        repr[5] = '\0';
     }
 }
 
 ////////////
 // CHESSPIECE
-const char ChessPiece::szDigits[11] = "0123456789";
+const char ChessPiece::digits[11] = "0123456789";
 
 ChessPiece::ChessPiece(bool isW, bool isKS, ChessBoard* b, int i)
     : isWhite(isW), isKingSide(isKS), board(b), index(i) {
     for (int j = 0; j < 4 + 1; j++) {
-        szID[j] = '\0';
+        id[j] = '\0';
     }
 
     if (isW)
-        szID[0] = 'W';
+        id[0] = 'W';
     else
-        szID[0] = 'B';
+        id[0] = 'B';
 
     if (isKS)
-        szID[2] = 'K';
+        id[2] = 'K';
     else
-        szID[2] = 'Q';
+        id[2] = 'Q';
 
-    if (i <= 10 && i >= 0) szID[3] = szDigits[i];
+    if (i <= 10 && i >= 0) id[3] = digits[i];
 }
 
 ChessPiece::~ChessPiece() {}
@@ -187,35 +186,35 @@ int ChessPiece::getPosY() const {
     return -1;
 }
 
-const char* ChessPiece::getID() const { return szID; }
+const char* ChessPiece::getID() const { return id; }
 
 bool ChessPiece::move(int x, int y) {
     if (canMove(x, y) &&
         board !=
             nullptr)  // not sure what happens when *(nullptr) used as reference; can't be good.
     {
-        delete f_getMoveablePiece(*board, x, y);  // check pointers !
-        f_movePiece(*board,
-                    ChessMove(getPosX(), getPosY(), x, y));  // and this will overwrite the pointer
+        delete getMutablePiece(*board, x, y);  // check pointers !
+        movePiece(*board,
+                  ChessMove(getPosX(), getPosY(), x, y));  // and this will overwrite the pointer
         return true;
     } else
         return false;
 }
 
-ChessPiece* ChessPiece::f_movePiece(ChessBoard& cb, ChessMove move) const {
+ChessPiece* ChessPiece::movePiece(ChessBoard& cb, ChessMove move) const {
     return cb.movePiece(move);
 }
 
-ChessPiece* ChessPiece::f_getMoveablePiece(ChessBoard& cb, int x, int y) const {
+ChessPiece* ChessPiece::getMutablePiece(ChessBoard& cb, int x, int y) const {
     return cb.getMoveablePiece(x, y);
 }
 
-ChessPiece* ChessPiece::f_setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const {
+ChessPiece* ChessPiece::setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const {
     if (x < 0 || x > 7 || y < 0 || y > 7)
         return nullptr;
     else {
-        ChessPiece* temp = cb.aapGrid[x][y];
-        cb.aapGrid[x][y] = piece;
+        ChessPiece* temp = cb.grid[x][y];
+        cb.grid[x][y] = piece;
         return temp;  // function caller's responsibility to prevent memory holes.
     }
 }
@@ -247,7 +246,7 @@ double ChessPiece::getValue() {
 // PAWN
 
 Pawn::Pawn(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
-    szID[1] = 'P';
+    id[1] = 'P';
     hasMoved = false;
     enPassant = false;
 }
@@ -258,10 +257,10 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
     if (x < 0 || x > 7 || y < 0 || y > 7)  // check bounds
         return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
-    if (y == yNow && board->getPiece(x, y) == nullptr)  // forward move
+    if (y == cy && board->getPiece(x, y) == nullptr)  // forward move
     {
         // Double advance: white unmoved pawn can jump from row 1 to row 3
         // (skipping row 2); black from row 6 to row 4 (skipping row 5).
@@ -270,40 +269,39 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
         else if (hasMoved == false && isWhite == false && x == 4 &&
                  board->getPiece(5, y) == nullptr)
             ;
-        else if (isWhite == true && x == xNow + 1)
+        else if (isWhite == true && x == cx + 1)
             ;
-        else if (isWhite == false && x == xNow - 1)
+        else if (isWhite == false && x == cx - 1)
             ;
         else
             return false;
-    } else if ((y == yNow + 1 || y == yNow - 1) &&
-               board->getPiece(x, y) == nullptr) {  // en passant
+    } else if ((y == cy + 1 || y == cy - 1) && board->getPiece(x, y) == nullptr) {  // en passant
         // En passant: white pawn must be on row 4 (opponent's double-advance
         // landing row); black pawn on row 3. The captured pawn sits on the
         // same row as the capturing pawn, one column over.
-        if (isWhite == true && xNow == 4 && board->getPiece(xNow, y) != nullptr &&
-            board->getPiece(xNow, y)->getWhite() == false &&
-            board->getPiece(xNow, y)->getType() == PAWN) {
-            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(xNow, y));
+        if (isWhite == true && cx == 4 && board->getPiece(cx, y) != nullptr &&
+            board->getPiece(cx, y)->getWhite() == false &&
+            board->getPiece(cx, y)->getType() == PAWN) {
+            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(cx, y));
             if (piece && piece->getEnPassant())
                 ;
             else
                 return false;
-        } else if (isWhite == false && xNow == 3 && board->getPiece(xNow, y) != nullptr &&
-                   board->getPiece(xNow, y)->getWhite() == true &&
-                   board->getPiece(xNow, y)->getType() == PAWN) {
-            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(xNow, y));
+        } else if (isWhite == false && cx == 3 && board->getPiece(cx, y) != nullptr &&
+                   board->getPiece(cx, y)->getWhite() == true &&
+                   board->getPiece(cx, y)->getType() == PAWN) {
+            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(cx, y));
             if (piece && piece->getEnPassant())
                 ;
             else
                 return false;
         } else
             return false;
-    } else if ((y == yNow + 1 || y == yNow - 1) &&
+    } else if ((y == cy + 1 || y == cy - 1) &&
                board->getPiece(x, y) != nullptr) {  // diagonal capture
-        if (isWhite == true && x == xNow + 1 && board->getPiece(x, y)->getWhite() == false)
+        if (isWhite == true && x == cx + 1 && board->getPiece(x, y)->getWhite() == false)
             ;
-        else if (isWhite == false && x == xNow - 1 && board->getPiece(x, y)->getWhite() == true)
+        else if (isWhite == false && x == cx - 1 && board->getPiece(x, y)->getWhite() == true)
             ;
         else
             return false;
@@ -312,13 +310,13 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute the move to test for self-check, then undo it.
-        // f_movePiece returns whatever piece was displaced at the destination
+        // movePiece returns whatever piece was displaced at the destination
         // (the capture candidate). After checking, we move our piece back and
-        // restore the displaced piece via f_setPiece.
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        // restore the displaced piece via setPiece.
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -367,8 +365,8 @@ bool Pawn::getEnPassant() const { return enPassant; }
 void Pawn::setEnPassant(bool b) { enPassant = b; }
 
 bool Pawn::move(int x, int y) {
-    int xPrev = getPosX();
-    int yPrev = getPosY();
+    int ox = getPosX();
+    int oy = getPosY();
 
     bool destEmpty = board->getPiece(x, y) == nullptr;
 
@@ -376,17 +374,17 @@ bool Pawn::move(int x, int y) {
     if (b) {
         hasMoved = true;
 
-        if (isWhite == true && x == xPrev + 1 && abs(y - yPrev) == 1 && destEmpty) {
-            ChessPiece* ePawn = f_getMoveablePiece(*board, xPrev, y);
-            delete ePawn;
-            f_setPiece(*board, xPrev, y, nullptr);
-        } else if (isWhite == false && x == xPrev - 1 && abs(y - yPrev) == 1 && destEmpty) {
-            ChessPiece* ePawn = f_getMoveablePiece(*board, xPrev, y);
-            delete ePawn;
-            f_setPiece(*board, xPrev, y, nullptr);
+        if (isWhite == true && x == ox + 1 && abs(y - oy) == 1 && destEmpty) {
+            ChessPiece* capturedPawn = getMutablePiece(*board, ox, y);
+            delete capturedPawn;
+            setPiece(*board, ox, y, nullptr);
+        } else if (isWhite == false && x == ox - 1 && abs(y - oy) == 1 && destEmpty) {
+            ChessPiece* capturedPawn = getMutablePiece(*board, ox, y);
+            delete capturedPawn;
+            setPiece(*board, ox, y, nullptr);
         }
 
-        if (abs(xPrev - x) == 2) enPassant = true;
+        if (abs(ox - x) == 2) enPassant = true;
     }
     return b;
 
@@ -399,7 +397,7 @@ PieceType Pawn::getType() const { return PAWN; }
 // ROOK
 
 Rook::Rook(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
-    szID[1] = 'R';
+    id[1] = 'R';
     hasMoved = false;
 }
 
@@ -408,37 +406,37 @@ Rook::~Rook() {}
 bool Rook::canMove(int x, int y, bool chkchk) const {
     if (x < 0 || x > 7 || y < 0 || y > 7) return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
     if (board->getPiece(x, y) != nullptr &&
         board->getPiece(x, y)->getWhite() == isWhite)  // capturing same-side piece.
         return false;
 
-    if (x == xNow) {
-        if (y == yNow)  // null moves don't count
+    if (x == cx) {
+        if (y == cy)  // null moves don't count
             return false;
         else  // check space in between
         {
-            if (y < yNow) {
-                for (int i = y + 1; i < yNow; i++) {
+            if (y < cy) {
+                for (int i = y + 1; i < cy; i++) {
                     if (board->getPiece(x, i) != nullptr) return false;
                 };
-            } else {  // y > yNow
-                for (int i = y - 1; i > yNow; i--) {
+            } else {  // y > cy
+                for (int i = y - 1; i > cy; i--) {
                     if (board->getPiece(x, i) != nullptr) return false;
                 };
             }
         }
-    } else if (y != yNow) {
+    } else if (y != cy) {
         return false;
     } else {  // check space in between again
-        if (x < xNow) {
-            for (int i = x + 1; i < xNow; i++) {
+        if (x < cx) {
+            for (int i = x + 1; i < cx; i++) {
                 if (board->getPiece(i, y) != nullptr) return false;
             };
-        } else {  // x > xNow
-            for (int i = x - 1; i > xNow; i--) {
+        } else {  // x > cx
+            for (int i = x - 1; i > cx; i--) {
                 if (board->getPiece(i, y) != nullptr) return false;
             };
         }
@@ -446,10 +444,10 @@ bool Rook::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -506,7 +504,7 @@ const int Knight::xOffsets[8] = {1, 1, -1, -1, 2, 2, -2, -2};
 const int Knight::yOffsets[8] = {2, -2, 2, -2, 1, -1, 1, -1};
 
 Knight::Knight(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
-    szID[1] = 'N';
+    id[1] = 'N';
 }
 
 Knight::~Knight() {}
@@ -517,16 +515,16 @@ bool Knight::canMove(int x, int y, bool chkchk) const {
     if (board->getPiece(x, y) != nullptr && board->getPiece(x, y)->getWhite() == isWhite)
         return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
-    if (abs(xNow - x) == 1) {
-        if (abs(yNow - y) == 2)
+    if (abs(cx - x) == 1) {
+        if (abs(cy - y) == 2)
             ;
         else
             return false;
-    } else if (abs(xNow - x) == 2) {
-        if (abs(yNow - y) == 1)
+    } else if (abs(cx - x) == 2) {
+        if (abs(cy - y) == 1)
             ;
         else
             return false;
@@ -535,10 +533,10 @@ bool Knight::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -570,7 +568,7 @@ PieceType Knight::getType() const { return KNIGHT; }
 // BISHOP
 
 Bishop::Bishop(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
-    szID[1] = 'B';
+    id[1] = 'B';
 }
 
 Bishop::~Bishop() {}
@@ -578,38 +576,38 @@ Bishop::~Bishop() {}
 bool Bishop::canMove(int x, int y, bool chkchk) const {
     if (x < 0 || x > 7 || y < 0 || y > 7) return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
-    int pyInt = yNow - xNow;
-    int nyInt = yNow + xNow;
+    int diagDiff = cy - cx;
+    int diagSum = cy + cx;
 
     if (board->getPiece(x, y) != nullptr &&
         board->getPiece(x, y)->getWhite() == isWhite)  // can't capture same side
         return false;
 
-    if (y - x == pyInt) {
-        if (x == xNow)
+    if (y - x == diagDiff) {
+        if (x == cx)
             return false;
-        else if (x > xNow) {
-            for (int i = 1; (yNow + i < y && xNow + i < x); i++) {
-                if (board->getPiece(xNow + i, yNow + i) != nullptr) return false;
+        else if (x > cx) {
+            for (int i = 1; (cy + i < y && cx + i < x); i++) {
+                if (board->getPiece(cx + i, cy + i) != nullptr) return false;
             };
-        } else {  // x < xNow
-            for (int i = 1; (yNow - i > y && xNow - i > x); i++) {
-                if (board->getPiece(xNow - i, yNow - i) != nullptr) return false;
+        } else {  // x < cx
+            for (int i = 1; (cy - i > y && cx - i > x); i++) {
+                if (board->getPiece(cx - i, cy - i) != nullptr) return false;
             };
         }
-    } else if (y + x == nyInt) {
-        if (x == xNow)
+    } else if (y + x == diagSum) {
+        if (x == cx)
             return false;
-        else if (x > xNow) {
-            for (int i = 1; (yNow - i > y && xNow + i < x); i++) {
-                if (board->getPiece(xNow + i, yNow - i) != nullptr) return false;
+        else if (x > cx) {
+            for (int i = 1; (cy - i > y && cx + i < x); i++) {
+                if (board->getPiece(cx + i, cy - i) != nullptr) return false;
             };
-        } else {  // x < xNow
-            for (int i = 1; (yNow + i < y && xNow - i > x); i++) {
-                if (board->getPiece(xNow - i, yNow + i) != nullptr) return false;
+        } else {  // x < cx
+            for (int i = 1; (cy + i < y && cx - i > x); i++) {
+                if (board->getPiece(cx - i, cy + i) != nullptr) return false;
             };
         }
     } else
@@ -617,10 +615,10 @@ bool Bishop::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -679,7 +677,7 @@ const int King::xOffsets[10] = {-1, -1, -1, 0, 0, 1, 1, 1, 0, 0};
 const int King::yOffsets[10] = {-1, 0, 1, -1, 1, -1, 0, 1, -2, 2};
 
 King::King(bool isW, ChessBoard* b) : ChessPiece(isW, true, b, 0) {
-    szID[1] = 'K';
+    id[1] = 'K';
     hasMoved = false;
 }
 
@@ -692,13 +690,13 @@ bool King::canMove(int x, int y, bool chkchk) const {
         board->getPiece(x, y)->getWhite() == isWhite)  // also disallows null move
         return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
-    if (abs(x - xNow) <= 1 && abs(y - yNow) <= 1)
+    if (abs(x - cx) <= 1 && abs(y - cy) <= 1)
         ;
     else {
-        if (abs(y - yNow) == 2 && x == xNow && !hasMoved)  // castling
+        if (abs(y - cy) == 2 && x == cx && !hasMoved)  // castling
         {
             if (chkchk && inCheck())  // can't castle out of check
                 return false;
@@ -706,36 +704,36 @@ bool King::canMove(int x, int y, bool chkchk) const {
             // sign: +1 = kingside (y increases), -1 = queenside (y decreases).
             // King always starts at column 4 (hard-coded assumption).
             // Rook column: (7 + 7*sign)/2 -> kingside=7, queenside=0.
-            int sign = (y - yNow) / 2;
+            int sign = (y - cy) / 2;
 
-            if (board->getPiece(xNow, 4 + sign) == nullptr &&
-                board->getPiece(xNow, 4 + 2 * sign) == nullptr &&
-                board->getPiece(xNow, (7 + 7 * sign) / 2) != nullptr)  // check rooks
+            if (board->getPiece(cx, 4 + sign) == nullptr &&
+                board->getPiece(cx, 4 + 2 * sign) == nullptr &&
+                board->getPiece(cx, (7 + 7 * sign) / 2) != nullptr)  // check rooks
             {
                 if (sign == -1 &&
-                    board->getPiece(xNow, 1) != nullptr)  // Queen side: b-file must also be empty
+                    board->getPiece(cx, 1) != nullptr)  // Queen side: b-file must also be empty
                     return false;
 
-                if (board->getPiece(xNow, (7 + 7 * sign) / 2)->getType() == ROOK &&
-                    board->getPiece(xNow, (7 + 7 * sign) / 2)->getWhite() == isWhite) {
+                if (board->getPiece(cx, (7 + 7 * sign) / 2)->getType() == ROOK &&
+                    board->getPiece(cx, (7 + 7 * sign) / 2)->getWhite() == isWhite) {
                     const Rook* piece =
-                        dynamic_cast<const Rook*>(board->getPiece(xNow, (7 + 7 * sign) / 2));
+                        dynamic_cast<const Rook*>(board->getPiece(cx, (7 + 7 * sign) / 2));
                     if (!piece->getMoved()) {
                         // Step the king through each intermediate square and verify
                         // it is not in check at any point (castling through check is illegal).
-                        f_movePiece(*board, ChessMove(xNow, 4, xNow, 4 + sign));
+                        movePiece(*board, ChessMove(cx, 4, cx, 4 + sign));
                         if (chkchk && inCheck()) {
-                            f_movePiece(*board, ChessMove(xNow, 4 + sign, xNow, 4));
+                            movePiece(*board, ChessMove(cx, 4 + sign, cx, 4));
                             return false;
                         }
 
-                        f_movePiece(*board, ChessMove(xNow, 4 + sign, xNow, 4 + sign * 2));
+                        movePiece(*board, ChessMove(cx, 4 + sign, cx, 4 + sign * 2));
                         if (chkchk && inCheck()) {
-                            f_movePiece(*board, ChessMove(xNow, 4 + sign * 2, xNow, 4));
+                            movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
                             return false;
                         }
 
-                        f_movePiece(*board, ChessMove(xNow, 4 + sign * 2, xNow, 4));
+                        movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
                     } else
                         return false;
                 } else
@@ -751,10 +749,10 @@ bool King::canMove(int x, int y, bool chkchk) const {
         // board scan. checkCheck() would search the board for this king and then
         // call inCheck() — but since we are already executing as the king, we
         // can call inCheck() directly. Both are equivalent; inCheck() is faster.
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(inCheck());
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -781,20 +779,20 @@ ChessMove* King::getMoves() const {
 }
 
 bool King::move(int x, int y) {
-    int xPrev = getPosX();
-    int yPrev = getPosY();
+    int ox = getPosX();
+    int oy = getPosY();
 
     bool b = ChessPiece::move(x, y);
     if (b) {
         hasMoved = true;
-        if (y == 6 && yPrev == 4) {
-            f_movePiece(*board, ChessMove(xPrev, 7, xPrev, 5));
-            Rook* piece = dynamic_cast<Rook*>(f_getMoveablePiece(*board, xPrev, 5));
+        if (y == 6 && oy == 4) {
+            movePiece(*board, ChessMove(ox, 7, ox, 5));
+            Rook* piece = dynamic_cast<Rook*>(getMutablePiece(*board, ox, 5));
             piece->markMoved();
         }
-        if (y == 2 && yPrev == 4) {
-            f_movePiece(*board, ChessMove(xPrev, 0, xPrev, 3));
-            Rook* piece = dynamic_cast<Rook*>(f_getMoveablePiece(*board, xPrev, 3));
+        if (y == 2 && oy == 4) {
+            movePiece(*board, ChessMove(ox, 0, ox, 3));
+            Rook* piece = dynamic_cast<Rook*>(getMutablePiece(*board, ox, 3));
             piece->markMoved();
         }
     }
@@ -802,8 +800,8 @@ bool King::move(int x, int y) {
 }
 
 bool King::inCheck() const {
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
     for (int i = 0; i < 8; i++) {
         for (int j = 0; j < 8; j++) {
@@ -813,7 +811,7 @@ bool King::inCheck() const {
             // reaches the king's square; asking whether *that* move would expose the
             // enemy's own king (chkchk=true) would restart the cycle and recurse forever.
             if (board->getPiece(i, j) != nullptr && board->getPiece(i, j)->getWhite() != isWhite &&
-                board->getPiece(i, j)->canMove(xNow, yNow, false))
+                board->getPiece(i, j)->canMove(cx, cy, false))
                 return true;
         }
     }
@@ -826,7 +824,7 @@ PieceType King::getType() const { return KING; }
 // QUEEN
 
 Queen::Queen(bool isW, ChessBoard* b, int i, bool isKS) : ChessPiece(isW, isKS, b, i) {
-    szID[1] = 'Q';
+    id[1] = 'Q';
 }
 
 Queen::~Queen() {}
@@ -838,61 +836,61 @@ bool Queen::canMove(int x, int y, bool chkchk) const {
         board->getPiece(x, y)->getWhite() == isWhite)  // also disallows null move
         return false;
 
-    int xNow = getPosX();
-    int yNow = getPosY();
+    int cx = getPosX();
+    int cy = getPosY();
 
-    int pyInt = yNow - xNow;
-    int nyInt = yNow + xNow;
+    int diagDiff = cy - cx;
+    int diagSum = cy + cx;
 
-    if (x == xNow) {
-        if (y == yNow)  // null moves don't count
+    if (x == cx) {
+        if (y == cy)  // null moves don't count
             return false;
         else  // check space in between
         {
-            if (y < yNow) {
-                for (int i = y + 1; i < yNow; i++) {
+            if (y < cy) {
+                for (int i = y + 1; i < cy; i++) {
                     if (board->getPiece(x, i) != nullptr) return false;
                 };
-            } else {  // y > yNow
-                for (int i = y - 1; i > yNow; i--) {
+            } else {  // y > cy
+                for (int i = y - 1; i > cy; i--) {
                     if (board->getPiece(x, i) != nullptr) return false;
                 };
             }
         }
-    } else if (y != yNow) {
-        if (y - x == pyInt) {
-            if (x == xNow)
+    } else if (y != cy) {
+        if (y - x == diagDiff) {
+            if (x == cx)
                 return false;
-            else if (x > xNow) {
-                for (int i = 1; (yNow + i < y && xNow + i < x); i++) {
-                    if (board->getPiece(xNow + i, yNow + i) != nullptr) return false;
+            else if (x > cx) {
+                for (int i = 1; (cy + i < y && cx + i < x); i++) {
+                    if (board->getPiece(cx + i, cy + i) != nullptr) return false;
                 };
-            } else {  // x < xNow
-                for (int i = 1; (yNow - i > y && xNow - i > x); i++) {
-                    if (board->getPiece(xNow - i, yNow - i) != nullptr) return false;
+            } else {  // x < cx
+                for (int i = 1; (cy - i > y && cx - i > x); i++) {
+                    if (board->getPiece(cx - i, cy - i) != nullptr) return false;
                 };
             }
-        } else if (y + x == nyInt) {
-            if (x == xNow)
+        } else if (y + x == diagSum) {
+            if (x == cx)
                 return false;
-            else if (x > xNow) {
-                for (int i = 1; (yNow - i > y && xNow + i < x); i++) {
-                    if (board->getPiece(xNow + i, yNow - i) != nullptr) return false;
+            else if (x > cx) {
+                for (int i = 1; (cy - i > y && cx + i < x); i++) {
+                    if (board->getPiece(cx + i, cy - i) != nullptr) return false;
                 };
-            } else {  // x < xNow
-                for (int i = 1; (yNow + i < y && xNow - i > x); i++) {
-                    if (board->getPiece(xNow - i, yNow + i) != nullptr) return false;
+            } else {  // x < cx
+                for (int i = 1; (cy + i < y && cx - i > x); i++) {
+                    if (board->getPiece(cx - i, cy + i) != nullptr) return false;
                 };
             }
         } else
             return false;
     } else {  // check space in between again
-        if (x < xNow) {
-            for (int i = x + 1; i < xNow; i++) {
+        if (x < cx) {
+            for (int i = x + 1; i < cx; i++) {
                 if (board->getPiece(i, y) != nullptr) return false;
             };
-        } else {  // x > xNow
-            for (int i = x - 1; i > xNow; i--) {
+        } else {  // x > cx
+            for (int i = x - 1; i > cx; i--) {
                 if (board->getPiece(i, y) != nullptr) return false;
             };
         }
@@ -900,10 +898,10 @@ bool Queen::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
-        f_setPiece(*board, x, y, temp);
+        movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
@@ -978,47 +976,47 @@ PieceType Queen::getType() const { return QUEEN; }
 ChessBoard::ChessBoard() {
     for (int i = 0; i < 8; i++) {
         for (int j = 0; j < 8; j++) {
-            aapGrid[i][j] = nullptr;
+            grid[i][j] = nullptr;
         }
     }
 
     // Set up the pieces
 
-    aapGrid[0][0] = new Rook(WHITE, false, this, 0);
-    aapGrid[0][1] = new Knight(WHITE, false, this, 0);
-    aapGrid[0][2] = new Bishop(WHITE, false, this, 0);
-    aapGrid[0][3] = new Queen(WHITE, this, 0);
-    aapGrid[0][4] = new King(WHITE, this);
-    aapGrid[0][5] = new Bishop(WHITE, true, this, 0);
-    aapGrid[0][6] = new Knight(WHITE, true, this, 0);
-    aapGrid[0][7] = new Rook(WHITE, true, this, 0);
+    grid[0][0] = new Rook(WHITE, false, this, 0);
+    grid[0][1] = new Knight(WHITE, false, this, 0);
+    grid[0][2] = new Bishop(WHITE, false, this, 0);
+    grid[0][3] = new Queen(WHITE, this, 0);
+    grid[0][4] = new King(WHITE, this);
+    grid[0][5] = new Bishop(WHITE, true, this, 0);
+    grid[0][6] = new Knight(WHITE, true, this, 0);
+    grid[0][7] = new Rook(WHITE, true, this, 0);
 
-    aapGrid[1][0] = new Pawn(WHITE, false, this, 4);
-    aapGrid[1][1] = new Pawn(WHITE, false, this, 3);
-    aapGrid[1][2] = new Pawn(WHITE, false, this, 2);
-    aapGrid[1][3] = new Pawn(WHITE, false, this, 1);
-    aapGrid[1][4] = new Pawn(WHITE, true, this, 1);
-    aapGrid[1][5] = new Pawn(WHITE, true, this, 2);
-    aapGrid[1][6] = new Pawn(WHITE, true, this, 3);
-    aapGrid[1][7] = new Pawn(WHITE, true, this, 4);
+    grid[1][0] = new Pawn(WHITE, false, this, 4);
+    grid[1][1] = new Pawn(WHITE, false, this, 3);
+    grid[1][2] = new Pawn(WHITE, false, this, 2);
+    grid[1][3] = new Pawn(WHITE, false, this, 1);
+    grid[1][4] = new Pawn(WHITE, true, this, 1);
+    grid[1][5] = new Pawn(WHITE, true, this, 2);
+    grid[1][6] = new Pawn(WHITE, true, this, 3);
+    grid[1][7] = new Pawn(WHITE, true, this, 4);
 
-    aapGrid[6][0] = new Pawn(BLACK, false, this, 4);
-    aapGrid[6][1] = new Pawn(BLACK, false, this, 3);
-    aapGrid[6][2] = new Pawn(BLACK, false, this, 2);
-    aapGrid[6][3] = new Pawn(BLACK, false, this, 1);
-    aapGrid[6][4] = new Pawn(BLACK, true, this, 1);
-    aapGrid[6][5] = new Pawn(BLACK, true, this, 2);
-    aapGrid[6][6] = new Pawn(BLACK, true, this, 3);
-    aapGrid[6][7] = new Pawn(BLACK, true, this, 4);
+    grid[6][0] = new Pawn(BLACK, false, this, 4);
+    grid[6][1] = new Pawn(BLACK, false, this, 3);
+    grid[6][2] = new Pawn(BLACK, false, this, 2);
+    grid[6][3] = new Pawn(BLACK, false, this, 1);
+    grid[6][4] = new Pawn(BLACK, true, this, 1);
+    grid[6][5] = new Pawn(BLACK, true, this, 2);
+    grid[6][6] = new Pawn(BLACK, true, this, 3);
+    grid[6][7] = new Pawn(BLACK, true, this, 4);
 
-    aapGrid[7][0] = new Rook(BLACK, false, this, 0);
-    aapGrid[7][1] = new Knight(BLACK, false, this, 0);
-    aapGrid[7][2] = new Bishop(BLACK, false, this, 0);
-    aapGrid[7][3] = new Queen(BLACK, this, 0);
-    aapGrid[7][4] = new King(BLACK, this);
-    aapGrid[7][5] = new Bishop(BLACK, true, this, 0);
-    aapGrid[7][6] = new Knight(BLACK, true, this, 0);
-    aapGrid[7][7] = new Rook(BLACK, true, this, 0);
+    grid[7][0] = new Rook(BLACK, false, this, 0);
+    grid[7][1] = new Knight(BLACK, false, this, 0);
+    grid[7][2] = new Bishop(BLACK, false, this, 0);
+    grid[7][3] = new Queen(BLACK, this, 0);
+    grid[7][4] = new King(BLACK, this);
+    grid[7][5] = new Bishop(BLACK, true, this, 0);
+    grid[7][6] = new Knight(BLACK, true, this, 0);
+    grid[7][7] = new Rook(BLACK, true, this, 0);
 }
 
 ChessBoard::~ChessBoard()  // do not keep pointers to pieces in this grid after the board is
@@ -1026,9 +1024,9 @@ ChessBoard::~ChessBoard()  // do not keep pointers to pieces in this grid after 
 {
     for (int i = 0; i < 8; i++) {
         for (int j = 0; j < 8; j++) {
-            if (aapGrid[i][j] != nullptr) {
-                delete aapGrid[i][j];
-                aapGrid[i][j] = nullptr;
+            if (grid[i][j] != nullptr) {
+                delete grid[i][j];
+                grid[i][j] = nullptr;
             }
         }
     }
@@ -1038,58 +1036,58 @@ const char* ChessBoard::toString() {
     // Layout: 8 ranks x 4 display rows/rank + 1 border row = 33 rows.
     // Each row: 8 squares x 5 chars/square + 1 border col = 41 chars + newline = 42.
     // Total: 42 * 33 + 1 (null terminator) = 1387 bytes.
-    szForm.assign(1387, '\0');  // 1387 = 42 * 33 + 1
+    repr.assign(1387, '\0');  // 1387 = 42 * 33 + 1
 
     bool white = false;
 
-    szForm[1386] = '\0';
+    repr[1386] = '\0';
 
     for (int i = 0; i < 33; i++)  // 33 rows
     {
-        szForm[42 * i + 41] = '\n';  // newlines
+        repr[42 * i + 41] = '\n';  // newlines
         if (i % 4 == 0) {
             for (int j = 0; j < 41; j++)  // 41 columns
             {
                 if (j % 5 == 0)
-                    szForm[42 * i + j] = '+';
+                    repr[42 * i + j] = '+';
                 else {
                     if (i == 0 || i == 32)
-                        szForm[42 * i + j] = ChessMove::szlcLetters[j / 5];
+                        repr[42 * i + j] = ChessMove::fileLetters[j / 5];
                     else
-                        szForm[42 * i + j] = '-';
+                        repr[42 * i + j] = '-';
                 }
             }
         } else if (i % 2 == 0) {
             for (int j = 0; j < 41; j++) {
                 if (j % 5 == 0) {
                     if (j == 0 || j == 40)
-                        szForm[42 * i + j] = ChessPiece::szDigits[8 - (i / 4)];
+                        repr[42 * i + j] = ChessPiece::digits[8 - (i / 4)];
                     else
-                        szForm[42 * i + j] = '|';
+                        repr[42 * i + j] = '|';
                 } else if (j % 5 == 1 || j % 5 == 4) {
-                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr)
-                        szForm[42 * i + j] = ' ';
+                    if (grid[7 - (i / 4)][j / 5] != nullptr)
+                        repr[42 * i + j] = ' ';
                     else {
                         white = (i / 4) % 2 == 0;
                         if ((j / 5) % 2 != 0) white = !white;
                         if (white)
-                            szForm[42 * i + j] = 'X';
+                            repr[42 * i + j] = 'X';
                         else
-                            szForm[42 * i + j] = ' ';
+                            repr[42 * i + j] = ' ';
                     }
                 } else {
-                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr) {
+                    if (grid[7 - (i / 4)][j / 5] != nullptr) {
                         if (j % 5 == 2)
-                            szForm[42 * i + j] = *((aapGrid[7 - (i / 4)][j / 5])->getID());
+                            repr[42 * i + j] = *((grid[7 - (i / 4)][j / 5])->getID());
                         else
-                            szForm[42 * i + j] = *((aapGrid[7 - (i / 4)][j / 5])->getID() + 1);
+                            repr[42 * i + j] = *((grid[7 - (i / 4)][j / 5])->getID() + 1);
                     } else {
                         white = (i / 4) % 2 == 0;
                         if ((j / 5) % 2 != 0) white = !white;
                         if (white)
-                            szForm[42 * i + j] = 'X';
+                            repr[42 * i + j] = 'X';
                         else
-                            szForm[42 * i + j] = ' ';
+                            repr[42 * i + j] = ' ';
                     }
                 }
             }
@@ -1097,47 +1095,47 @@ const char* ChessBoard::toString() {
             for (int j = 0; j < 41; j++) {
                 if (j % 5 == 0) {
                     if (j == 0 || j == 40)
-                        szForm[42 * i + j] = ChessPiece::szDigits[8 - (i / 4)];
+                        repr[42 * i + j] = ChessPiece::digits[8 - (i / 4)];
                     else
-                        szForm[42 * i + j] = '|';
+                        repr[42 * i + j] = '|';
                 } else if (j % 5 == 1 || j % 5 == 4) {
                     white = (i / 4) % 2 == 0;
                     if ((j / 5) % 2 != 0) white = !white;
                     if (white)
-                        szForm[42 * i + j] = 'X';
+                        repr[42 * i + j] = 'X';
                     else
-                        szForm[42 * i + j] = ' ';
+                        repr[42 * i + j] = ' ';
                 } else {
-                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr)
-                        szForm[42 * i + j] = ' ';
+                    if (grid[7 - (i / 4)][j / 5] != nullptr)
+                        repr[42 * i + j] = ' ';
                     else {
                         white = (i / 4) % 2 == 0;
                         if ((j / 5) % 2 != 0) white = !white;
                         if (white)
-                            szForm[42 * i + j] = 'X';
+                            repr[42 * i + j] = 'X';
                         else
-                            szForm[42 * i + j] = ' ';
+                            repr[42 * i + j] = ' ';
                     }
                 }
             }
         }
     }
-    return szForm.c_str();
+    return repr.c_str();
 }
 
 ChessPiece* ChessBoard::getMoveablePiece(int x, int y) {
     if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
-        return aapGrid[x][y];
+        return grid[x][y];
     else
         return nullptr;
 }
 
 ChessPiece* ChessBoard::movePiece(ChessMove move) {
-    if (!move.isEnd() && aapGrid[move.getStartX()][move.getStartY()] != nullptr) {
-        ChessPiece* temp = aapGrid[move.getEndX()][move.getEndY()];
-        aapGrid[move.getEndX()][move.getEndY()] =
-            aapGrid[move.getStartX()][move.getStartY()];        // replaces destination
-        aapGrid[move.getStartX()][move.getStartY()] = nullptr;  // leaves behind nothing
+    if (!move.isEnd() && grid[move.getStartX()][move.getStartY()] != nullptr) {
+        ChessPiece* temp = grid[move.getEndX()][move.getEndY()];
+        grid[move.getEndX()][move.getEndY()] =
+            grid[move.getStartX()][move.getStartY()];        // replaces destination
+        grid[move.getStartX()][move.getStartY()] = nullptr;  // leaves behind nothing
         return temp;
     } else
         return nullptr;
@@ -1145,7 +1143,7 @@ ChessPiece* ChessBoard::movePiece(ChessMove move) {
 
 const ChessPiece* ChessBoard::getPiece(int x, int y) const {
     if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
-        return aapGrid[x][y];
+        return grid[x][y];
     else
         return nullptr;
 }
@@ -1153,8 +1151,8 @@ const ChessPiece* ChessBoard::getPiece(int x, int y) const {
 bool ChessBoard::checkCheck(bool isW) const {
     for (int i = 0; i < 8; i++) {
         for (int j = 0; j < 8; j++) {
-            if (aapGrid[i][j] != nullptr && (aapGrid[i][j])->getType() == KING &&
-                (aapGrid[i][j])->getWhite() == isW) {
+            if (grid[i][j] != nullptr && (grid[i][j])->getType() == KING &&
+                (grid[i][j])->getWhite() == isW) {
                 const King* piece = dynamic_cast<const King*>(getPiece(i, j));
                 if (piece && piece->inCheck())
                     return true;
@@ -1305,8 +1303,8 @@ void ChessGame::setPiece(int x, int y, ChessPiece* piece) {
 
     if (x < 0 || x > 7 || y < 0 || y > 7) return;
 
-    delete board.aapGrid[x][y];
-    board.aapGrid[x][y] = piece;
+    delete board.grid[x][y];
+    board.grid[x][y] = piece;
 }
 
 ChessBoard* ChessGame::getPieceBoard() { return &board; }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1,24 +1,19 @@
 // This is the chess.cpp file which contains implementations for the headers in chess.h
 
-
 #include "chess.h"
 
-/*                                                                                                 1
-         1         2         3         4         5         6         7         8         9         0         1         2
-1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901
-*/
+#include <cstdlib>
 
-int abs(int x) { return x < 0 ? -x : x; }
+using std::abs;
 
 ///////////
-//CHESSMOVE
+// CHESSMOVE
 const ChessMove ChessMove::end = ChessMove();
 const char ChessMove::szlcLetters[8 + 1] = "abcdefgh";
-const int ChessMove::MAXCMLENGTH = 1024;                // 669 should be sufficient for all moves of both sides, FYI
+const int ChessMove::MAXCMLENGTH =
+    1024;  // 669 should be sufficient for all moves of both sides, FYI
 
-ChessMove::ChessMove():
-data(0) 
-{
+ChessMove::ChessMove() : data(0) {
     szForm[3] = '\0';
     szForm[0] = 'E';
     szForm[1] = 'N';
@@ -27,132 +22,96 @@ data(0)
     szForm[5] = '\0';
 }
 
-ChessMove::ChessMove( int sX, int sY, int eX, int eY ):
-data(0)
-{
-    init( sX, sY, eX, eY );
+ChessMove::ChessMove(int sX, int sY, int eX, int eY) : data(0) { init(sX, sY, eX, eY); }
 
-}
-
-ChessMove::ChessMove( const char * const pszMove ):
-data(0)
-{
+ChessMove::ChessMove(const char* const pszMove) : data(0) {
     int sY = (int)(pszMove[0] - 'a');
     int sX = (int)(pszMove[1] - '1');
-    
+
     int eX, eY;
-    
-    if ( pszMove[2] == ' '  ||  pszMove[2] == '-' )
-    {
+
+    if (pszMove[2] == ' ' || pszMove[2] == '-') {
         eY = (int)(pszMove[3] - 'a');
         eX = (int)(pszMove[4] - '1');
     } else {
         eY = (int)(pszMove[2] - 'a');
         eX = (int)(pszMove[3] - '1');
     }
-    init( sX, sY, eX, eY );
+    init(sX, sY, eX, eY);
 }
 
-ChessMove::ChessMove( const ChessMove & rcm ):
-data( rcm.data )
-{
-    for( int i = 0; i < 6; i++ )
-    {
+ChessMove::ChessMove(const ChessMove& rcm) : data(rcm.data) {
+    for (int i = 0; i < 6; i++) {
         szForm[i] = rcm.szForm[i];
     }
 }
 
+ChessMove::~ChessMove() {}
 
-ChessMove::~ChessMove()
-{}
+ChessMove& ChessMove::operator=(const ChessMove& rhs) {
+    if (this == &rhs) return *this;
 
-ChessMove & ChessMove::operator=( const ChessMove & rhs )
-{
-    if ( this == &rhs )
-        return *this;
-    
     data = rhs.data;
-    for( int i = 0; i < 6; i++ )
-    {
+    for (int i = 0; i < 6; i++) {
         szForm[i] = rhs.szForm[i];
     }
     return *this;
 }
 
 int ChessMove::getStartX() const { return data & 0x7; }
-int ChessMove::getStartY() const { return ( data & 0x38 ) / 0x8 ; }
-int ChessMove::getEndX() const { return ( data & 0x1c0 ) / 0x40; }
-int ChessMove::getEndY() const { return ( data & 0xe00 ) / 0x200 ; }
+int ChessMove::getStartY() const { return (data & 0x38) / 0x8; }
+int ChessMove::getEndX() const { return (data & 0x1c0) / 0x40; }
+int ChessMove::getEndY() const { return (data & 0xe00) / 0x200; }
 
-bool ChessMove::isEnd() const
-{
-    return ( data == 0 );
-}
+bool ChessMove::isEnd() const { return (data == 0); }
 
-void ChessMove::swap( ChessMove & cm1, ChessMove & cm2 )
-{
+void ChessMove::swap(ChessMove& cm1, ChessMove& cm2) {
     ChessMove temp = cm1;
     cm1 = cm2;
     cm2 = temp;
 }
 
-void ChessMove::sort( ChessMove * acm, int size )
-{
-    for( int j, i = 0; i < size - 1; i++ )            // sort the ::ends to the end ( ::end like \0 in string )
+void ChessMove::sort(ChessMove* acm, int size) {
+    for (int j, i = 0; i < size - 1; i++)  // sort the ::ends to the end ( ::end like \0 in string )
     {
-        if ( acm[i].isEnd() )
-        {
-            for( j = i + 1; j < size; j++ )
-            {
-                if ( !acm[j].isEnd() )
-                {
-                    ChessMove::swap( acm[i], acm[j] );
+        if (acm[i].isEnd()) {
+            for (j = i + 1; j < size; j++) {
+                if (!acm[j].isEnd()) {
+                    ChessMove::swap(acm[i], acm[j]);
                     break;
                 }
             }
-            if ( j == size )       // nothing to swap with?
+            if (j == size)  // nothing to swap with?
                 break;
         }
     }
 }
 
-int ChessMove::length( ChessMove const * cm )
-{
-    if ( cm == NULL )
-        return 0;
+int ChessMove::length(ChessMove const* cm) {
+    if (cm == nullptr) return 0;
     int l;
-    for( l = 0; !(cm[l].isEnd())  &&  l < MAXCMLENGTH; l++ );
+    for (l = 0; !(cm[l].isEnd()) && l < MAXCMLENGTH; l++);
     return l;
 }
 
-void ChessMove::copy( ChessMove * cm1, const ChessMove * cm2 )
-{
-    int l = length( cm2 );
-    for( int i = 0; i <= l; i++ )
-    {
+void ChessMove::copy(ChessMove* cm1, const ChessMove* cm2) {
+    int l = length(cm2);
+    for (int i = 0; i <= l; i++) {
         cm1[i] = cm2[i];
     }
 }
 
-void ChessMove::concat( ChessMove * cm1, const ChessMove * cm2 )
-{
-    int l = length( cm1 );
-    if ( cm1[l].isEnd() )
-        copy( cm1 + l, cm2 );
+void ChessMove::concat(ChessMove* cm1, const ChessMove* cm2) {
+    int l = length(cm1);
+    if (cm1[l].isEnd()) copy(cm1 + l, cm2);
 }
 
-const char * ChessMove::toString() const
-{
-    return szForm;
-}
+const char* ChessMove::toString() const { return szForm; }
 
-void ChessMove::init( int sX, int sY, int eX, int eY )
-{
-    if ( sX < 0  ||  sX > 7  || sY < 0  ||  sY > 7  ||
-         eX < 0  ||  eX > 7  || eY < 0  ||  eY > 7 )
+void ChessMove::init(int sX, int sY, int eX, int eY) {
+    if (sX < 0 || sX > 7 || sY < 0 || sY > 7 || eX < 0 || eX > 7 || eY < 0 || eY > 7)
         ;
-    else
-    {
+    else {
         short int startX = (short int)sX;
         short int startY = (short int)sY;
         short int endX = (short int)eX;
@@ -162,15 +121,14 @@ void ChessMove::init( int sX, int sY, int eX, int eY )
         data += endX * 8 * 8;
         data += endY * 8 * 8 * 8;
     }
-    
-    if ( !isEnd() )
-    {
+
+    if (!isEnd()) {
         szForm[5] = '\0';
         szForm[2] = '-';
         szForm[0] = szlcLetters[getStartY()];
-        szForm[1] = ChessPiece::szDigits[getStartX()+1];
+        szForm[1] = ChessPiece::szDigits[getStartX() + 1];
         szForm[3] = szlcLetters[getEndY()];
-        szForm[4] = ChessPiece::szDigits[getEndX()+1];
+        szForm[4] = ChessPiece::szDigits[getEndX() + 1];
     } else {
         szForm[3] = '\0';
         szForm[0] = 'E';
@@ -182,29 +140,26 @@ void ChessMove::init( int sX, int sY, int eX, int eY )
 }
 
 ////////////
-//CHESSPIECE
+// CHESSPIECE
 const char ChessPiece::szDigits[11] = "0123456789";
 
-ChessPiece::ChessPiece( bool isW, bool isKS, ChessBoard * b, int i ):
-isWhite(isW), isKingSide(isKS), board(b), index(i)
-{
-    for( int j = 0; j < 4 + 1; j++ )
-    {
+ChessPiece::ChessPiece(bool isW, bool isKS, ChessBoard* b, int i)
+    : isWhite(isW), isKingSide(isKS), board(b), index(i) {
+    for (int j = 0; j < 4 + 1; j++) {
         szID[j] = '\0';
     }
-    
-    if ( isW )
+
+    if (isW)
         szID[0] = 'W';
     else
         szID[0] = 'B';
-        
-    if ( isKS )
+
+    if (isKS)
         szID[2] = 'K';
     else
         szID[2] = 'Q';
-    
-    if ( i <= 10  &&  i >= 0 )
-        szID[3] = szDigits[i];
+
+    if (i <= 10 && i >= 0) szID[3] = szDigits[i];
 }
 
 ChessPiece::~ChessPiece() {}
@@ -213,71 +168,60 @@ int ChessPiece::getIndex() const { return index; }
 bool ChessPiece::getWhite() const { return isWhite; }
 bool ChessPiece::getKingSide() const { return isKingSide; }
 
-int ChessPiece::getPosX() const             // O(64) scan; position is not stored on the piece
+int ChessPiece::getPosX() const  // O(64) scan; position is not stored on the piece
 {
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( board->getPiece( i, j ) == this )
-                return i;
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (board->getPiece(i, j) == this) return i;
         }
     }
     return -1;
 }
 
-int ChessPiece::getPosY() const
-{
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( board->getPiece( i, j ) == this )
-                return j;
+int ChessPiece::getPosY() const {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (board->getPiece(i, j) == this) return j;
         }
     }
     return -1;
 }
 
-const char * ChessPiece::getID() const { return szID; }
+const char* ChessPiece::getID() const { return szID; }
 
-bool ChessPiece::move( int x, int y )
-{
-    if ( canMove( x, y )  &&  board != NULL )   // not sure what happens when *(NULL) used as reference; can't be good.
+bool ChessPiece::move(int x, int y) {
+    if (canMove(x, y) &&
+        board !=
+            nullptr)  // not sure what happens when *(nullptr) used as reference; can't be good.
     {
-        delete f_getMoveablePiece( *board, x, y );                          // check pointers !
-        f_movePiece( *board, ChessMove( getPosX(), getPosY(), x, y ) );     // and this will overwrite the pointer
+        delete f_getMoveablePiece(*board, x, y);  // check pointers !
+        f_movePiece(*board,
+                    ChessMove(getPosX(), getPosY(), x, y));  // and this will overwrite the pointer
         return true;
     } else
         return false;
 }
 
-ChessPiece * ChessPiece::f_movePiece( ChessBoard & cb, ChessMove move ) const
-{
-    return cb.movePiece( move );
+ChessPiece* ChessPiece::f_movePiece(ChessBoard& cb, ChessMove move) const {
+    return cb.movePiece(move);
 }
 
-ChessPiece * ChessPiece::f_getMoveablePiece( ChessBoard & cb, int x, int y ) const
-{
-    return cb.getMoveablePiece( x, y );
+ChessPiece* ChessPiece::f_getMoveablePiece(ChessBoard& cb, int x, int y) const {
+    return cb.getMoveablePiece(x, y);
 }
 
-ChessPiece * ChessPiece::f_setPiece( ChessBoard & cb, int x, int y, ChessPiece * piece ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
-        return NULL;
-    else
-    {
-        ChessPiece * temp = cb.aapGrid[x][y];
+ChessPiece* ChessPiece::f_setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7)
+        return nullptr;
+    else {
+        ChessPiece* temp = cb.aapGrid[x][y];
         cb.aapGrid[x][y] = piece;
-        return temp;         //function caller's responsibility to prevent memory holes.
+        return temp;  // function caller's responsibility to prevent memory holes.
     }
 }
 
-int ChessPiece::getRootValue()
-{
-    switch( getType() )
-    {
+int ChessPiece::getRootValue() {
+    switch (getType()) {
         case PAWN:
             return 1;
         case ROOK:
@@ -293,20 +237,16 @@ int ChessPiece::getRootValue()
     }
 }
 
-double ChessPiece::getValue()
-{
+double ChessPiece::getValue() {
     double value = getRootValue();
-    
+
     return value;
 }
 
-
 //////
-//PAWN
+// PAWN
 
-Pawn::Pawn( bool isW, bool isKS, ChessBoard * b, int i ):
-ChessPiece(isW,isKS,b,i)
-{   
+Pawn::Pawn(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
     szID[1] = 'P';
     hasMoved = false;
     enPassant = false;
@@ -314,277 +254,244 @@ ChessPiece(isW,isKS,b,i)
 
 Pawn::~Pawn() {}
 
-bool Pawn::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )       // check bounds
+bool Pawn::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7)  // check bounds
         return false;
-    
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
-    if ( y == yNow  &&  board->getPiece( x, y ) == NULL )         // forward move
+
+    if (y == yNow && board->getPiece(x, y) == nullptr)  // forward move
     {
         // Double advance: white unmoved pawn can jump from row 1 to row 3
         // (skipping row 2); black from row 6 to row 4 (skipping row 5).
-        if ( hasMoved == false  &&  isWhite == true  &&  x == 3  &&  board->getPiece( 2, y ) == NULL )
-            ;                                                       // Would be return true; need to check for check
-        else if ( hasMoved == false  &&  isWhite == false  &&  x == 4  &&  board->getPiece( 5, y ) == NULL )
+        if (hasMoved == false && isWhite == true && x == 3 && board->getPiece(2, y) == nullptr)
+            ;  // Would be return true; need to check for check
+        else if (hasMoved == false && isWhite == false && x == 4 &&
+                 board->getPiece(5, y) == nullptr)
             ;
-        else if ( isWhite == true  &&  x == xNow + 1 )
+        else if (isWhite == true && x == xNow + 1)
             ;
-        else if ( isWhite == false  &&  x == xNow - 1 )
+        else if (isWhite == false && x == xNow - 1)
             ;
         else
             return false;
-    } else if ( ( y == yNow + 1  ||  y == yNow - 1 )  &&  board->getPiece( x, y ) == NULL ) {     // en passant
+    } else if ((y == yNow + 1 || y == yNow - 1) &&
+               board->getPiece(x, y) == nullptr) {  // en passant
         // En passant: white pawn must be on row 4 (opponent's double-advance
         // landing row); black pawn on row 3. The captured pawn sits on the
         // same row as the capturing pawn, one column over.
-        if ( isWhite == true  &&  xNow == 4  &&  board->getPiece( xNow, y ) != NULL  &&
-                board->getPiece( xNow, y )->getWhite() == false  &&  board->getPiece( xNow, y )->getType() == PAWN )
-        {
-            const Pawn * piece = dynamic_cast<const Pawn *>(board->getPiece( xNow, y ));
-            if ( piece  &&  piece->getEnPassant() )
+        if (isWhite == true && xNow == 4 && board->getPiece(xNow, y) != nullptr &&
+            board->getPiece(xNow, y)->getWhite() == false &&
+            board->getPiece(xNow, y)->getType() == PAWN) {
+            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(xNow, y));
+            if (piece && piece->getEnPassant())
                 ;
             else
                 return false;
-        } else if ( isWhite == false  &&  xNow == 3  &&  board->getPiece( xNow, y ) != NULL  &&
-                    board->getPiece( xNow, y )->getWhite() == true  &&  board->getPiece( xNow, y )->getType() == PAWN )
-        {
-            const Pawn * piece = dynamic_cast<const Pawn *>(board->getPiece( xNow, y ));
-            if ( piece  &&  piece->getEnPassant() )
+        } else if (isWhite == false && xNow == 3 && board->getPiece(xNow, y) != nullptr &&
+                   board->getPiece(xNow, y)->getWhite() == true &&
+                   board->getPiece(xNow, y)->getType() == PAWN) {
+            const Pawn* piece = dynamic_cast<const Pawn*>(board->getPiece(xNow, y));
+            if (piece && piece->getEnPassant())
                 ;
             else
                 return false;
         } else
             return false;
-    } else if ( ( y == yNow + 1  ||  y == yNow - 1 )  &&  board->getPiece( x, y ) != NULL ) {      // diagonal capture
-        if ( isWhite == true  &&  x == xNow + 1  &&  board->getPiece( x, y )->getWhite() == false )
+    } else if ((y == yNow + 1 || y == yNow - 1) &&
+               board->getPiece(x, y) != nullptr) {  // diagonal capture
+        if (isWhite == true && x == xNow + 1 && board->getPiece(x, y)->getWhite() == false)
             ;
-        else if ( isWhite == false  &&  x == xNow - 1  &&  board->getPiece( x, y )->getWhite() == true )
+        else if (isWhite == false && x == xNow - 1 && board->getPiece(x, y)->getWhite() == true)
             ;
         else
             return false;
     } else
         return false;
-    
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Temporarily execute the move to test for self-check, then undo it.
         // f_movePiece returns whatever piece was displaced at the destination
         // (the capture candidate). After checking, we move our piece back and
         // restore the displaced piece via f_setPiece.
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
-        bool ret = !(board->checkCheck( isWhite ));
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        bool ret = !(board->checkCheck(isWhite));
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * Pawn::getMoves() const
-{
+ChessMove* Pawn::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
+
     int sign = 1;
-    if ( !isWhite )
-        sign -= 2;
-    
-    ChessMove * ret = new ChessMove[4 + 1];
-    if ( !ret )
-    {
-        return NULL;
+    if (!isWhite) sign -= 2;
+
+    ChessMove* ret = new ChessMove[4 + 1];
+    if (!ret) {
+        return nullptr;
     }
-    
+
     ret[4] = ChessMove::end;
-    
-    if ( canMove( x + sign, y ) )
-        ret[0] = ChessMove( x, y, x + sign, y );
+
+    if (canMove(x + sign, y))
+        ret[0] = ChessMove(x, y, x + sign, y);
     else
         ret[0] = ChessMove::end;
-    
-    if ( canMove( x + 2 * sign, y ) )
-        ret[1] = ChessMove( x, y, x + 2 * sign, y );
+
+    if (canMove(x + 2 * sign, y))
+        ret[1] = ChessMove(x, y, x + 2 * sign, y);
     else
         ret[1] = ChessMove::end;
-    
-    if ( canMove( x + sign, y + 1 ) )
-        ret[2] = ChessMove( x, y, x + sign, y + 1 );
+
+    if (canMove(x + sign, y + 1))
+        ret[2] = ChessMove(x, y, x + sign, y + 1);
     else
         ret[2] = ChessMove::end;
-    
-    if ( canMove( x + sign, y - 1 ) )
-        ret[3] = ChessMove( x, y, x + sign, y - 1 );
+
+    if (canMove(x + sign, y - 1))
+        ret[3] = ChessMove(x, y, x + sign, y - 1);
     else
         ret[3] = ChessMove::end;
-    
-    ChessMove::sort( ret, 5 );          // sort the ::ends to the end
+
+    ChessMove::sort(ret, 5);  // sort the ::ends to the end
     return ret;
 }
 
 bool Pawn::getMoved() const { return hasMoved; }
 bool Pawn::getEnPassant() const { return enPassant; }
-void Pawn::setEnPassant( bool b ) { enPassant = b; }
+void Pawn::setEnPassant(bool b) { enPassant = b; }
 
-bool Pawn::move( int x, int y )
-{
+bool Pawn::move(int x, int y) {
     int xPrev = getPosX();
     int yPrev = getPosY();
-    
-    bool destEmpty = board->getPiece( x, y ) == NULL;
-    
-    bool b = ChessPiece::move( x, y );
-    if ( b )
-    {
+
+    bool destEmpty = board->getPiece(x, y) == nullptr;
+
+    bool b = ChessPiece::move(x, y);
+    if (b) {
         hasMoved = true;
-        
-        if ( isWhite == true  &&  x == xPrev + 1  &&  abs( y - yPrev ) == 1  &&  destEmpty )
-        {
-            ChessPiece * ePawn = f_getMoveablePiece( *board, xPrev, y );
+
+        if (isWhite == true && x == xPrev + 1 && abs(y - yPrev) == 1 && destEmpty) {
+            ChessPiece* ePawn = f_getMoveablePiece(*board, xPrev, y);
             delete ePawn;
-            f_setPiece( *board, xPrev, y, NULL );
-        } else if ( isWhite == false  &&  x == xPrev - 1  &&  abs( y - yPrev ) == 1  &&  destEmpty ) {
-            ChessPiece * ePawn = f_getMoveablePiece( *board, xPrev, y );
+            f_setPiece(*board, xPrev, y, nullptr);
+        } else if (isWhite == false && x == xPrev - 1 && abs(y - yPrev) == 1 && destEmpty) {
+            ChessPiece* ePawn = f_getMoveablePiece(*board, xPrev, y);
             delete ePawn;
-            f_setPiece( *board, xPrev, y, NULL );
+            f_setPiece(*board, xPrev, y, nullptr);
         }
-        
-        if ( abs( xPrev - x ) == 2 )
-            enPassant = true;
+
+        if (abs(xPrev - x) == 2) enPassant = true;
     }
     return b;
-    
-    //promotion to be covered elsewhere
+
+    // promotion to be covered elsewhere
 }
 
 PieceType Pawn::getType() const { return PAWN; }
 
 //////
-//ROOK
+// ROOK
 
-Rook::Rook( bool isW, bool isKS, ChessBoard * b, int i ):
-ChessPiece(isW,isKS,b,i)
-{
+Rook::Rook(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
     szID[1] = 'R';
     hasMoved = false;
 }
 
 Rook::~Rook() {}
 
-bool Rook::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
-        return false;
-    
+bool Rook::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return false;
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
-    if ( board->getPiece( x, y ) != NULL  &&  board->getPiece( x, y )->getWhite() == isWhite )  // capturing same-side piece.
+
+    if (board->getPiece(x, y) != nullptr &&
+        board->getPiece(x, y)->getWhite() == isWhite)  // capturing same-side piece.
         return false;
-    
-    if ( x == xNow )
-    {
-        if ( y == yNow )                // null moves don't count
+
+    if (x == xNow) {
+        if (y == yNow)  // null moves don't count
             return false;
-        else                            // check space in between
+        else  // check space in between
         {
-            if ( y < yNow )
-            {
-                for( int i = y + 1; i < yNow; i++ )
-                {
-                    if ( board->getPiece( x, i ) != NULL )
-                        return false;
-                }
-                ;
-            } else {     // y > yNow
-                for( int i = y - 1; i > yNow; i-- )
-                {
-                    if ( board->getPiece( x, i ) != NULL )
-                        return false;
-                }
-                ;
+            if (y < yNow) {
+                for (int i = y + 1; i < yNow; i++) {
+                    if (board->getPiece(x, i) != nullptr) return false;
+                };
+            } else {  // y > yNow
+                for (int i = y - 1; i > yNow; i--) {
+                    if (board->getPiece(x, i) != nullptr) return false;
+                };
             }
         }
-    } else if ( y != yNow ) {
+    } else if (y != yNow) {
         return false;
-    } else {                // check space in between again
-        if ( x < xNow )
-        {
-            for( int i = x + 1; i < xNow; i++ )
-            {
-                if ( board->getPiece( i, y ) != NULL )
-                    return false;
-            }
-            ;
-        } else {        // x > xNow
-            for( int i = x - 1; i > xNow; i-- )
-            {
-                if ( board->getPiece( i, y ) != NULL )
-                    return false;
-            }
-            ;
+    } else {  // check space in between again
+        if (x < xNow) {
+            for (int i = x + 1; i < xNow; i++) {
+                if (board->getPiece(i, y) != nullptr) return false;
+            };
+        } else {  // x > xNow
+            for (int i = x - 1; i > xNow; i--) {
+                if (board->getPiece(i, y) != nullptr) return false;
+            };
         }
     }
-    
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
-        bool ret = !(board->checkCheck( isWhite ));
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        bool ret = !(board->checkCheck(isWhite));
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * Rook::getMoves() const
-{
+ChessMove* Rook::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
-    ChessMove * ret = new ChessMove[14 + 1];
-    if ( !ret )
-        return NULL;
-    
-    for( int i = 0; i < 15; i++ )           // all blank to start
+
+    ChessMove* ret = new ChessMove[14 + 1];
+    if (!ret) return nullptr;
+
+    for (int i = 0; i < 15; i++)  // all blank to start
     {
         ret[i] = ChessMove::end;
     }
-    
-    for( int i = 0, j = 0; i < 8; i++ )     // add move in the same row
+
+    for (int i = 0, j = 0; i < 8; i++)  // add move in the same row
     {
-        if ( y != i )
-        {
-            if ( canMove( x, i ) )
-                ret[j] = ChessMove( x, y, x, i );
+        if (y != i) {
+            if (canMove(x, i)) ret[j] = ChessMove(x, y, x, i);
             j++;
         }
     }
-    
-    for( int i = 0, j = 7; i < 8; i++ )     // add moves in the same column
+
+    for (int i = 0, j = 7; i < 8; i++)  // add moves in the same column
     {
-        if ( x != i )
-        {
-            if ( canMove( i, y ) )
-                ret[j] = ChessMove( x, y, i, y );
+        if (x != i) {
+            if (canMove(i, y)) ret[j] = ChessMove(x, y, i, y);
             j++;
         }
     }
-    
-    ChessMove::sort( ret, 15 );
+
+    ChessMove::sort(ret, 15);
     return ret;
 }
 
 bool Rook::getMoved() const { return hasMoved; }
 
-bool Rook::move( int x, int y )
-{
-    bool b = ChessPiece::move( x, y );
-    if ( b )
-        markMoved();
+bool Rook::move(int x, int y) {
+    bool b = ChessPiece::move(x, y);
+    if (b) markMoved();
     return b;
 }
 
@@ -593,287 +500,242 @@ PieceType Rook::getType() const { return ROOK; }
 void Rook::markMoved() { hasMoved = true; }
 
 ////////
-//KNIGHT
+// KNIGHT
 
-const int Knight::xOffsets[8] = { 1,  1, -1, -1, 2,  2, -2, -2 };
-const int Knight::yOffsets[8] = { 2, -2,  2, -2, 1, -1,  1, -1 };
+const int Knight::xOffsets[8] = {1, 1, -1, -1, 2, 2, -2, -2};
+const int Knight::yOffsets[8] = {2, -2, 2, -2, 1, -1, 1, -1};
 
-Knight::Knight( bool isW, bool isKS, ChessBoard * b, int i ):
-ChessPiece(isW,isKS,b,i)
-{
+Knight::Knight(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
     szID[1] = 'N';
 }
 
 Knight::~Knight() {}
 
-bool Knight::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
+bool Knight::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return false;
+
+    if (board->getPiece(x, y) != nullptr && board->getPiece(x, y)->getWhite() == isWhite)
         return false;
-    
-    if ( board->getPiece( x, y ) != NULL  &&  board->getPiece( x, y )->getWhite() == isWhite )
-        return false;
-    
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
-    if ( abs( xNow - x ) == 1 )
-    {
-        if ( abs( yNow - y ) == 2 )
+
+    if (abs(xNow - x) == 1) {
+        if (abs(yNow - y) == 2)
             ;
         else
             return false;
-    } else if ( abs( xNow - x ) == 2 ) {
-        if ( abs( yNow - y ) == 1 )
+    } else if (abs(xNow - x) == 2) {
+        if (abs(yNow - y) == 1)
             ;
         else
             return false;
     } else
         return false;
-        
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
-        bool ret = !(board->checkCheck( isWhite ));
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        bool ret = !(board->checkCheck(isWhite));
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * Knight::getMoves() const
-{
+ChessMove* Knight::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
-    ChessMove * ret = new ChessMove[8 + 1];
-    if ( !ret )
-        return NULL;
-    
-    for( int i = 0; i < 9; i++ )
-    {
+
+    ChessMove* ret = new ChessMove[8 + 1];
+    if (!ret) return nullptr;
+
+    for (int i = 0; i < 9; i++) {
         ret[i] = ChessMove::end;
     }
-    
-    for( int i = 0; i < 8; i++ )
-    {
-        if ( canMove( x + xOffsets[i], y + yOffsets[i] ) )
-            ret[i] = ChessMove( x, y, x + xOffsets[i], y + yOffsets[i] );
+
+    for (int i = 0; i < 8; i++) {
+        if (canMove(x + xOffsets[i], y + yOffsets[i]))
+            ret[i] = ChessMove(x, y, x + xOffsets[i], y + yOffsets[i]);
     }
-    
-    ChessMove::sort( ret, 9 );
+
+    ChessMove::sort(ret, 9);
     return ret;
 }
 
 PieceType Knight::getType() const { return KNIGHT; }
 
 ////////
-//BISHOP
+// BISHOP
 
-Bishop::Bishop( bool isW, bool isKS, ChessBoard * b, int i ):
-ChessPiece(isW,isKS,b,i)
-{
+Bishop::Bishop(bool isW, bool isKS, ChessBoard* b, int i) : ChessPiece(isW, isKS, b, i) {
     szID[1] = 'B';
 }
 
 Bishop::~Bishop() {}
 
-bool Bishop::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
-        return false;
-    
+bool Bishop::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return false;
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
+
     int pyInt = yNow - xNow;
     int nyInt = yNow + xNow;
-    
-    if ( board->getPiece( x, y ) != NULL  &&  board->getPiece( x, y )->getWhite() == isWhite )    // can't capture same side
+
+    if (board->getPiece(x, y) != nullptr &&
+        board->getPiece(x, y)->getWhite() == isWhite)  // can't capture same side
         return false;
-    
-    if ( y - x == pyInt )
-    {
-        if ( x == xNow )
+
+    if (y - x == pyInt) {
+        if (x == xNow)
             return false;
-        else if ( x > xNow )
-        {
-            for( int i = 1; ( yNow + i < y  &&  xNow + i < x ); i++ )
-            {
-                if ( board->getPiece( xNow + i, yNow + i ) != NULL )
-                    return false;
-            }
-            ;
-        } else {    // x < xNow
-            for( int i = 1; ( yNow - i > y  &&  xNow - i > x ); i++ )
-            {
-                if ( board->getPiece( xNow - i, yNow - i ) != NULL )
-                    return false;
-            }
-            ;
+        else if (x > xNow) {
+            for (int i = 1; (yNow + i < y && xNow + i < x); i++) {
+                if (board->getPiece(xNow + i, yNow + i) != nullptr) return false;
+            };
+        } else {  // x < xNow
+            for (int i = 1; (yNow - i > y && xNow - i > x); i++) {
+                if (board->getPiece(xNow - i, yNow - i) != nullptr) return false;
+            };
         }
-    } else if ( y + x == nyInt ) {
-        if ( x == xNow )
+    } else if (y + x == nyInt) {
+        if (x == xNow)
             return false;
-        else if ( x > xNow )
-        {
-            for( int i = 1; ( yNow - i > y  &&  xNow + i < x ); i++ )
-            {
-                if ( board->getPiece( xNow + i, yNow - i ) != NULL )
-                    return false;
-            }
-            ;
-        } else {    // x < xNow
-            for( int i = 1; ( yNow + i < y  &&  xNow - i > x ); i++ )
-            {
-                if ( board->getPiece( xNow - i, yNow + i ) != NULL )
-                    return false;
-            }
-            ;
+        else if (x > xNow) {
+            for (int i = 1; (yNow - i > y && xNow + i < x); i++) {
+                if (board->getPiece(xNow + i, yNow - i) != nullptr) return false;
+            };
+        } else {  // x < xNow
+            for (int i = 1; (yNow + i < y && xNow - i > x); i++) {
+                if (board->getPiece(xNow - i, yNow + i) != nullptr) return false;
+            };
         }
     } else
         return false;
-        
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
-        bool ret = !(board->checkCheck( isWhite ));
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        bool ret = !(board->checkCheck(isWhite));
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * Bishop::getMoves() const
-{
+ChessMove* Bishop::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
-    ChessMove * ret = new ChessMove[13 + 1];
-    if ( !ret )
-        return NULL;
-    
-    for( int i = 0; i < 14; i++ )
-    {
+
+    ChessMove* ret = new ChessMove[13 + 1];
+    if (!ret) return nullptr;
+
+    for (int i = 0; i < 14; i++) {
         ret[i] = ChessMove::end;
     }
-    
+
     int i = 0;
-    for( int j = 0;( x + j < 8  &&  y + j < 8 ); j++ )
-    {
-        if ( canMove( x + j, y + j ) )
-        {
-            ret[i] = ChessMove( x, y, x + j, y + j );
+    for (int j = 0; (x + j < 8 && y + j < 8); j++) {
+        if (canMove(x + j, y + j)) {
+            ret[i] = ChessMove(x, y, x + j, y + j);
             i++;
         }
     }
-    
-    for( int j = 0;( x - j >= 0  &&  y - j >= 0 ); j++ )
-    {
-        if ( canMove( x - j, y - j ) )
-        {
-            ret[i] = ChessMove( x, y, x - j, y - j );
+
+    for (int j = 0; (x - j >= 0 && y - j >= 0); j++) {
+        if (canMove(x - j, y - j)) {
+            ret[i] = ChessMove(x, y, x - j, y - j);
             i++;
         }
     }
-    
-    for( int j = 0;( x + j < 8  &&  y - j >= 0 ); j++ )
-    {
-        if ( canMove( x + j, y - j ) )
-        {
-            ret[i] = ChessMove( x, y, x + j, y - j );
+
+    for (int j = 0; (x + j < 8 && y - j >= 0); j++) {
+        if (canMove(x + j, y - j)) {
+            ret[i] = ChessMove(x, y, x + j, y - j);
             i++;
         }
     }
-    
-    for( int j = 0; ( x - j >= 0  &&  y + j < 8 ); j++ )
-    {
-        if ( canMove( x - j, y + j ) )
-        {
-            ret[i] = ChessMove( x, y, x - j, y + j );
+
+    for (int j = 0; (x - j >= 0 && y + j < 8); j++) {
+        if (canMove(x - j, y + j)) {
+            ret[i] = ChessMove(x, y, x - j, y + j);
             i++;
         }
     }
-    
-    ChessMove::sort( ret, 14 );         // shouldn't be necessary; if so returns quickly.
+
+    ChessMove::sort(ret, 14);  // shouldn't be necessary; if so returns quickly.
     return ret;
 }
 
 PieceType Bishop::getType() const { return BISHOP; }
 
 //////
-//KING
+// KING
 
-const int King::xOffsets[10] = { -1, -1, -1,  0, 0,  1, 1, 1,  0, 0 };
-const int King::yOffsets[10] = { -1,  0,  1, -1, 1, -1, 0, 1, -2, 2 };
+const int King::xOffsets[10] = {-1, -1, -1, 0, 0, 1, 1, 1, 0, 0};
+const int King::yOffsets[10] = {-1, 0, 1, -1, 1, -1, 0, 1, -2, 2};
 
-King::King( bool isW, ChessBoard * b ):
-ChessPiece(isW,true,b,0)
-{
+King::King(bool isW, ChessBoard* b) : ChessPiece(isW, true, b, 0) {
     szID[1] = 'K';
     hasMoved = false;
 }
 
 King::~King() {}
 
-bool King::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
+bool King::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return false;
+
+    if (board->getPiece(x, y) != nullptr &&
+        board->getPiece(x, y)->getWhite() == isWhite)  // also disallows null move
         return false;
-    
-    if ( board->getPiece( x, y ) != NULL  &&  board->getPiece( x, y )->getWhite() == isWhite )  // also disallows null move
-        return false;
-    
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
-    if ( abs( x - xNow ) <= 1  &&  abs( y - yNow ) <= 1 )
-    ;
-    else
-    {
-        if ( abs( y - yNow ) == 2  &&  x == xNow  &&  !hasMoved )         // castling
+
+    if (abs(x - xNow) <= 1 && abs(y - yNow) <= 1)
+        ;
+    else {
+        if (abs(y - yNow) == 2 && x == xNow && !hasMoved)  // castling
         {
-            if ( chkchk  &&  inCheck() )                // can't castle out of check
+            if (chkchk && inCheck())  // can't castle out of check
                 return false;
 
             // sign: +1 = kingside (y increases), -1 = queenside (y decreases).
             // King always starts at column 4 (hard-coded assumption).
             // Rook column: (7 + 7*sign)/2 -> kingside=7, queenside=0.
-            int sign = ( y - yNow ) / 2;
+            int sign = (y - yNow) / 2;
 
-            if ( board->getPiece( xNow, 4 + sign ) == NULL  &&  board->getPiece( xNow, 4 + 2 * sign ) == NULL  &&
-                    board->getPiece( xNow, ( 7 + 7 * sign ) / 2 ) != NULL )       // check rooks
+            if (board->getPiece(xNow, 4 + sign) == nullptr &&
+                board->getPiece(xNow, 4 + 2 * sign) == nullptr &&
+                board->getPiece(xNow, (7 + 7 * sign) / 2) != nullptr)  // check rooks
             {
-	        if ( sign == -1  &&  board->getPiece( xNow, 1 ) != NULL )   // Queen side: b-file must also be empty
-		    return false;
+                if (sign == -1 &&
+                    board->getPiece(xNow, 1) != nullptr)  // Queen side: b-file must also be empty
+                    return false;
 
-                if ( board->getPiece( xNow, ( 7 + 7 * sign ) / 2 )->getType() == ROOK  &&
-                        board->getPiece( xNow, ( 7 + 7 * sign ) / 2 )->getWhite() == isWhite )
-                {
-                    const Rook * piece = dynamic_cast<const Rook *>(board->getPiece( xNow, ( 7 + 7 * sign ) / 2 ));
-                    if ( !piece->getMoved() )
-                    {
+                if (board->getPiece(xNow, (7 + 7 * sign) / 2)->getType() == ROOK &&
+                    board->getPiece(xNow, (7 + 7 * sign) / 2)->getWhite() == isWhite) {
+                    const Rook* piece =
+                        dynamic_cast<const Rook*>(board->getPiece(xNow, (7 + 7 * sign) / 2));
+                    if (!piece->getMoved()) {
                         // Step the king through each intermediate square and verify
                         // it is not in check at any point (castling through check is illegal).
-                        f_movePiece( *board, ChessMove( xNow, 4, xNow, 4 + sign ) );
-                        if ( chkchk  &&  inCheck() )
-                        {
-                            f_movePiece( *board, ChessMove( xNow, 4 + sign, xNow, 4 ) );
+                        f_movePiece(*board, ChessMove(xNow, 4, xNow, 4 + sign));
+                        if (chkchk && inCheck()) {
+                            f_movePiece(*board, ChessMove(xNow, 4 + sign, xNow, 4));
                             return false;
                         }
 
-                        f_movePiece( *board, ChessMove( xNow, 4 + sign, xNow, 4 + sign * 2 ) );
-                        if ( chkchk  &&  inCheck() )
-                        {
-                            f_movePiece( *board, ChessMove( xNow, 4 + sign * 2, xNow, 4 ) );
+                        f_movePiece(*board, ChessMove(xNow, 4 + sign, xNow, 4 + sign * 2));
+                        if (chkchk && inCheck()) {
+                            f_movePiece(*board, ChessMove(xNow, 4 + sign * 2, xNow, 4));
                             return false;
                         }
 
-                        f_movePiece( *board, ChessMove( xNow, 4 + sign * 2, xNow, 4 ) );
+                        f_movePiece(*board, ChessMove(xNow, 4 + sign * 2, xNow, 4));
                     } else
                         return false;
                 } else
@@ -883,87 +745,75 @@ bool King::canMove( int x, int y, bool chkchk ) const
         } else
             return false;
     }
-    
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Call inCheck() directly rather than checkCheck() to avoid an extra
         // board scan. checkCheck() would search the board for this king and then
         // call inCheck() — but since we are already executing as the king, we
         // can call inCheck() directly. Both are equivalent; inCheck() is faster.
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
         bool ret = !(inCheck());
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * King::getMoves() const
-{
+ChessMove* King::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
-    ChessMove * ret = new ChessMove[10 + 1];
-    if ( !ret )
-        return NULL;
-    
-    for( int i = 0; i < 11; i++ )
-    {
+
+    ChessMove* ret = new ChessMove[10 + 1];
+    if (!ret) return nullptr;
+
+    for (int i = 0; i < 11; i++) {
         ret[i] = ChessMove::end;
     }
-    
-    for( int i = 0; i < 10; i++ )
-    {
-        if ( canMove( x + xOffsets[i], y + yOffsets[i] ) )
-            ret[i] = ChessMove( x, y, x + xOffsets[i], y + yOffsets[i] );
+
+    for (int i = 0; i < 10; i++) {
+        if (canMove(x + xOffsets[i], y + yOffsets[i]))
+            ret[i] = ChessMove(x, y, x + xOffsets[i], y + yOffsets[i]);
     }
-    
-    ChessMove::sort( ret, 11 );
+
+    ChessMove::sort(ret, 11);
     return ret;
 }
 
-bool King::move( int x, int y )
-{
+bool King::move(int x, int y) {
     int xPrev = getPosX();
     int yPrev = getPosY();
-    
-    bool b = ChessPiece::move( x, y );
-    if ( b )
-    {
+
+    bool b = ChessPiece::move(x, y);
+    if (b) {
         hasMoved = true;
-        if ( y == 6  &&  yPrev == 4 )
-        {
-            f_movePiece( *board, ChessMove( xPrev, 7, xPrev, 5 ) );
-            Rook * piece = dynamic_cast<Rook *>(f_getMoveablePiece( *board, xPrev, 5 ));
+        if (y == 6 && yPrev == 4) {
+            f_movePiece(*board, ChessMove(xPrev, 7, xPrev, 5));
+            Rook* piece = dynamic_cast<Rook*>(f_getMoveablePiece(*board, xPrev, 5));
             piece->markMoved();
         }
-        if ( y == 2  &&  yPrev == 4 )
-        {
-            f_movePiece( *board, ChessMove( xPrev, 0, xPrev, 3 ) );
-            Rook * piece = dynamic_cast<Rook *>(f_getMoveablePiece( *board, xPrev, 3 ));
+        if (y == 2 && yPrev == 4) {
+            f_movePiece(*board, ChessMove(xPrev, 0, xPrev, 3));
+            Rook* piece = dynamic_cast<Rook*>(f_getMoveablePiece(*board, xPrev, 3));
             piece->markMoved();
         }
     }
     return b;
 }
 
-bool King::inCheck() const
-{
+bool King::inCheck() const {
     int xNow = getPosX();
     int yNow = getPosY();
 
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
             // canMove(..., chkchk=false): passing false breaks the recursion cycle.
             // The full chain is: canMove(true) -> checkCheck -> inCheck -> canMove(false).
             // At this final step we only need to know if the enemy piece geometrically
             // reaches the king's square; asking whether *that* move would expose the
             // enemy's own king (chkchk=true) would restart the cycle and recurse forever.
-            if ( board->getPiece( i, j ) != NULL  &&  board->getPiece( i, j )->getWhite() != isWhite  &&
-                    board->getPiece( i, j )->canMove( xNow, yNow, false ) )
+            if (board->getPiece(i, j) != nullptr && board->getPiece(i, j)->getWhite() != isWhite &&
+                board->getPiece(i, j)->canMove(xNow, yNow, false))
                 return true;
         }
     }
@@ -973,340 +823,270 @@ bool King::inCheck() const
 PieceType King::getType() const { return KING; }
 
 ///////
-//QUEEN
+// QUEEN
 
-Queen::Queen( bool isW, ChessBoard * b, int i, bool isKS ):
-ChessPiece(isW,isKS,b,i)
-{
+Queen::Queen(bool isW, ChessBoard* b, int i, bool isKS) : ChessPiece(isW, isKS, b, i) {
     szID[1] = 'Q';
 }
 
 Queen::~Queen() {}
 
-bool Queen::canMove( int x, int y, bool chkchk ) const
-{
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
+bool Queen::canMove(int x, int y, bool chkchk) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return false;
+
+    if (board->getPiece(x, y) != nullptr &&
+        board->getPiece(x, y)->getWhite() == isWhite)  // also disallows null move
         return false;
-    
-    if ( board->getPiece( x, y ) != NULL  &&  board->getPiece( x, y )->getWhite() == isWhite )  // also disallows null move
-        return false;
-        
+
     int xNow = getPosX();
     int yNow = getPosY();
-    
+
     int pyInt = yNow - xNow;
     int nyInt = yNow + xNow;
-    
-    if ( x == xNow )
-    {
-        if ( y == yNow )                // null moves don't count
+
+    if (x == xNow) {
+        if (y == yNow)  // null moves don't count
             return false;
-        else                            // check space in between
+        else  // check space in between
         {
-            if ( y < yNow )
-            {
-                for( int i = y + 1; i < yNow; i++ )
-                {
-                    if ( board->getPiece( x, i ) != NULL )
-                        return false;
-                }
-                ;
-            } else {     // y > yNow
-                for( int i = y - 1; i > yNow; i-- )
-                {
-                    if ( board->getPiece( x, i ) != NULL )
-                        return false;
-                }
-                ;
+            if (y < yNow) {
+                for (int i = y + 1; i < yNow; i++) {
+                    if (board->getPiece(x, i) != nullptr) return false;
+                };
+            } else {  // y > yNow
+                for (int i = y - 1; i > yNow; i--) {
+                    if (board->getPiece(x, i) != nullptr) return false;
+                };
             }
         }
-    } else if ( y != yNow ) {
-        if ( y - x == pyInt )
-        {
-            if ( x == xNow )
+    } else if (y != yNow) {
+        if (y - x == pyInt) {
+            if (x == xNow)
                 return false;
-            else if ( x > xNow )
-            {
-                for( int i = 1; ( yNow + i < y  &&  xNow + i < x ); i++ )
-                {
-                    if ( board->getPiece( xNow + i, yNow + i ) != NULL )
-                        return false;
-                }
-                ;
-            } else {    // x < xNow
-                for( int i = 1; ( yNow - i > y  &&  xNow - i > x ); i++ )
-                {
-                    if ( board->getPiece( xNow - i, yNow - i ) != NULL )
-                        return false;
-                }
-                ;
+            else if (x > xNow) {
+                for (int i = 1; (yNow + i < y && xNow + i < x); i++) {
+                    if (board->getPiece(xNow + i, yNow + i) != nullptr) return false;
+                };
+            } else {  // x < xNow
+                for (int i = 1; (yNow - i > y && xNow - i > x); i++) {
+                    if (board->getPiece(xNow - i, yNow - i) != nullptr) return false;
+                };
             }
-        } else if ( y + x == nyInt ) {
-            if ( x == xNow )
+        } else if (y + x == nyInt) {
+            if (x == xNow)
                 return false;
-            else if ( x > xNow )
-            {
-                for( int i = 1; ( yNow - i > y  &&  xNow + i < x ); i++ )
-                {
-                    if ( board->getPiece( xNow + i, yNow - i ) != NULL )
-                        return false;
-                }
-                ;
-            } else {    // x < xNow
-                for( int i = 1; ( yNow + i < y  &&  xNow - i > x ); i++ )
-                {
-                    if ( board->getPiece( xNow - i, yNow + i ) != NULL )
-                        return false;
-                }
-                ;
+            else if (x > xNow) {
+                for (int i = 1; (yNow - i > y && xNow + i < x); i++) {
+                    if (board->getPiece(xNow + i, yNow - i) != nullptr) return false;
+                };
+            } else {  // x < xNow
+                for (int i = 1; (yNow + i < y && xNow - i > x); i++) {
+                    if (board->getPiece(xNow - i, yNow + i) != nullptr) return false;
+                };
             }
         } else
             return false;
-    } else {                // check space in between again
-        if ( x < xNow )
-        {
-            for( int i = x + 1; i < xNow; i++ )
-            {
-                if ( board->getPiece( i, y ) != NULL )
-                    return false;
-            }
-            ;
-        } else {        // x > xNow
-            for( int i = x - 1; i > xNow; i-- )
-            {
-                if ( board->getPiece( i, y ) != NULL )
-                    return false;
-            }
-            ;
+    } else {  // check space in between again
+        if (x < xNow) {
+            for (int i = x + 1; i < xNow; i++) {
+                if (board->getPiece(i, y) != nullptr) return false;
+            };
+        } else {  // x > xNow
+            for (int i = x - 1; i > xNow; i--) {
+                if (board->getPiece(i, y) != nullptr) return false;
+            };
         }
     }
-    
-    if ( chkchk )
-    {
+
+    if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece * temp = f_movePiece( *board, ChessMove( xNow, yNow, x, y ) );
-        bool ret = !(board->checkCheck( isWhite ));
-        f_movePiece( *board, ChessMove( x, y, xNow, yNow ) );
-        f_setPiece( *board, x, y, temp );
+        ChessPiece* temp = f_movePiece(*board, ChessMove(xNow, yNow, x, y));
+        bool ret = !(board->checkCheck(isWhite));
+        f_movePiece(*board, ChessMove(x, y, xNow, yNow));
+        f_setPiece(*board, x, y, temp);
         return ret;
     } else
         return true;
 }
 
-ChessMove * Queen::getMoves() const
-{
+ChessMove* Queen::getMoves() const {
     int x = getPosX();
     int y = getPosY();
-    
-    ChessMove * ret = new ChessMove[27 + 1];
-    if ( !ret )
-        return NULL;
-    
-    for( int i = 0; i < 28; i++ )           // all blank to start
+
+    ChessMove* ret = new ChessMove[27 + 1];
+    if (!ret) return nullptr;
+
+    for (int i = 0; i < 28; i++)  // all blank to start
     {
         ret[i] = ChessMove::end;
     }
-    
-    for( int i = 0, j = 0; i < 8; i++ )     // add move in the same row
+
+    for (int i = 0, j = 0; i < 8; i++)  // add move in the same row
     {
-        if ( y != i )
-        {
-            if ( canMove( x, i ) )
-                ret[j] = ChessMove( x, y, x, i );
+        if (y != i) {
+            if (canMove(x, i)) ret[j] = ChessMove(x, y, x, i);
             j++;
         }
     }
-    
-    for( int i = 0, j = 7; i < 8; i++ )     // add moves in the same column
+
+    for (int i = 0, j = 7; i < 8; i++)  // add moves in the same column
     {
-        if ( x != i )
-        {
-            if ( canMove( i, y ) )
-                ret[j] = ChessMove( x, y, i, y );
+        if (x != i) {
+            if (canMove(i, y)) ret[j] = ChessMove(x, y, i, y);
             j++;
         }
     }
-    
+
     int i = 14;
-    for( int j = 0;( x + j < 8  &&  y + j < 8 ); j++ )
-    {
-        if ( canMove( x + j, y + j ) )
-        {
-            ret[i] = ChessMove( x, y, x + j, y + j );
+    for (int j = 0; (x + j < 8 && y + j < 8); j++) {
+        if (canMove(x + j, y + j)) {
+            ret[i] = ChessMove(x, y, x + j, y + j);
             i++;
         }
     }
-    
-    for( int j = 0;( x - j >= 0  &&  y - j >= 0 ); j++ )
-    {
-        if ( canMove( x - j, y - j ) )
-        {
-            ret[i] = ChessMove( x, y, x - j, y - j );
+
+    for (int j = 0; (x - j >= 0 && y - j >= 0); j++) {
+        if (canMove(x - j, y - j)) {
+            ret[i] = ChessMove(x, y, x - j, y - j);
             i++;
         }
     }
-    
-    for( int j = 0;( x + j < 8  &&  y - j >= 0 ); j++ )
-    {
-        if ( canMove( x + j, y - j ) )
-        {
-            ret[i] = ChessMove( x, y, x + j, y - j );
+
+    for (int j = 0; (x + j < 8 && y - j >= 0); j++) {
+        if (canMove(x + j, y - j)) {
+            ret[i] = ChessMove(x, y, x + j, y - j);
             i++;
         }
     }
-    
-    for( int j = 0; ( x - j >= 0  &&  y + j < 8 ); j++ )
-    {
-        if ( canMove( x - j, y + j ) )
-        {
-            ret[i] = ChessMove( x, y, x - j, y + j );
+
+    for (int j = 0; (x - j >= 0 && y + j < 8); j++) {
+        if (canMove(x - j, y + j)) {
+            ret[i] = ChessMove(x, y, x - j, y + j);
             i++;
         }
     }
-    
-    ChessMove::sort( ret, 28 );
+
+    ChessMove::sort(ret, 28);
     return ret;
 }
 
 PieceType Queen::getType() const { return QUEEN; }
 
 ////////////
-//CHESSBOARD
+// CHESSBOARD
 
-
-ChessBoard::ChessBoard():
-szForm(NULL)
-{
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            aapGrid[i][j] = NULL;
+ChessBoard::ChessBoard() {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            aapGrid[i][j] = nullptr;
         }
     }
-    
-    //Set up the pieces
-    
-    aapGrid[0][0] = new Rook( WHITE, false, this, 0 );
-    aapGrid[0][1] = new Knight( WHITE, false, this, 0 );
-    aapGrid[0][2] = new Bishop( WHITE, false, this, 0 );
-    aapGrid[0][3] = new Queen( WHITE, this, 0 );
-    aapGrid[0][4] = new King( WHITE, this );
-    aapGrid[0][5] = new Bishop( WHITE, true, this, 0 );
-    aapGrid[0][6] = new Knight( WHITE, true, this, 0 );
-    aapGrid[0][7] = new Rook( WHITE, true, this, 0 );
-    
-    aapGrid[1][0] = new Pawn( WHITE, false, this, 4 );
-    aapGrid[1][1] = new Pawn( WHITE, false, this, 3 );
-    aapGrid[1][2] = new Pawn( WHITE, false, this, 2 );
-    aapGrid[1][3] = new Pawn( WHITE, false, this, 1 );
-    aapGrid[1][4] = new Pawn( WHITE, true, this, 1 );
-    aapGrid[1][5] = new Pawn( WHITE, true, this, 2 );
-    aapGrid[1][6] = new Pawn( WHITE, true, this, 3 );
-    aapGrid[1][7] = new Pawn( WHITE, true, this, 4 );
-    
-    aapGrid[6][0] = new Pawn( BLACK, false, this, 4 );
-    aapGrid[6][1] = new Pawn( BLACK, false, this, 3 );
-    aapGrid[6][2] = new Pawn( BLACK, false, this, 2 );
-    aapGrid[6][3] = new Pawn( BLACK, false, this, 1 );
-    aapGrid[6][4] = new Pawn( BLACK, true, this, 1 );
-    aapGrid[6][5] = new Pawn( BLACK, true, this, 2 );
-    aapGrid[6][6] = new Pawn( BLACK, true, this, 3 );
-    aapGrid[6][7] = new Pawn( BLACK, true, this, 4 );
-    
-    aapGrid[7][0] = new Rook( BLACK, false, this, 0 );
-    aapGrid[7][1] = new Knight( BLACK, false, this, 0 );
-    aapGrid[7][2] = new Bishop( BLACK, false, this, 0 );
-    aapGrid[7][3] = new Queen( BLACK, this, 0 );
-    aapGrid[7][4] = new King( BLACK, this );
-    aapGrid[7][5] = new Bishop( BLACK, true, this, 0 );
-    aapGrid[7][6] = new Knight( BLACK, true, this, 0 );
-    aapGrid[7][7] = new Rook( BLACK, true, this, 0 );
+
+    // Set up the pieces
+
+    aapGrid[0][0] = new Rook(WHITE, false, this, 0);
+    aapGrid[0][1] = new Knight(WHITE, false, this, 0);
+    aapGrid[0][2] = new Bishop(WHITE, false, this, 0);
+    aapGrid[0][3] = new Queen(WHITE, this, 0);
+    aapGrid[0][4] = new King(WHITE, this);
+    aapGrid[0][5] = new Bishop(WHITE, true, this, 0);
+    aapGrid[0][6] = new Knight(WHITE, true, this, 0);
+    aapGrid[0][7] = new Rook(WHITE, true, this, 0);
+
+    aapGrid[1][0] = new Pawn(WHITE, false, this, 4);
+    aapGrid[1][1] = new Pawn(WHITE, false, this, 3);
+    aapGrid[1][2] = new Pawn(WHITE, false, this, 2);
+    aapGrid[1][3] = new Pawn(WHITE, false, this, 1);
+    aapGrid[1][4] = new Pawn(WHITE, true, this, 1);
+    aapGrid[1][5] = new Pawn(WHITE, true, this, 2);
+    aapGrid[1][6] = new Pawn(WHITE, true, this, 3);
+    aapGrid[1][7] = new Pawn(WHITE, true, this, 4);
+
+    aapGrid[6][0] = new Pawn(BLACK, false, this, 4);
+    aapGrid[6][1] = new Pawn(BLACK, false, this, 3);
+    aapGrid[6][2] = new Pawn(BLACK, false, this, 2);
+    aapGrid[6][3] = new Pawn(BLACK, false, this, 1);
+    aapGrid[6][4] = new Pawn(BLACK, true, this, 1);
+    aapGrid[6][5] = new Pawn(BLACK, true, this, 2);
+    aapGrid[6][6] = new Pawn(BLACK, true, this, 3);
+    aapGrid[6][7] = new Pawn(BLACK, true, this, 4);
+
+    aapGrid[7][0] = new Rook(BLACK, false, this, 0);
+    aapGrid[7][1] = new Knight(BLACK, false, this, 0);
+    aapGrid[7][2] = new Bishop(BLACK, false, this, 0);
+    aapGrid[7][3] = new Queen(BLACK, this, 0);
+    aapGrid[7][4] = new King(BLACK, this);
+    aapGrid[7][5] = new Bishop(BLACK, true, this, 0);
+    aapGrid[7][6] = new Knight(BLACK, true, this, 0);
+    aapGrid[7][7] = new Rook(BLACK, true, this, 0);
 }
 
-ChessBoard::~ChessBoard()               // do not keep pointers to pieces in this grid after the board is destroyed
+ChessBoard::~ChessBoard()  // do not keep pointers to pieces in this grid after the board is
+                           // destroyed
 {
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( aapGrid[i][j] != NULL )
-            {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (aapGrid[i][j] != nullptr) {
                 delete aapGrid[i][j];
-                aapGrid[i][j] = NULL;
+                aapGrid[i][j] = nullptr;
             }
         }
     }
-    
-    delete[] szForm;
-    szForm = NULL;
 }
 
-const char * ChessBoard::toString()
-{
+const char* ChessBoard::toString() {
     // Layout: 8 ranks x 4 display rows/rank + 1 border row = 33 rows.
     // Each row: 8 squares x 5 chars/square + 1 border col = 41 chars + newline = 42.
     // Total: 42 * 33 + 1 (null terminator) = 1387 bytes.
-    if ( szForm == NULL )
-        szForm = new char[1387];        // 1387 = 42 * 33 + 1
-    if ( szForm == NULL )
-        return NULL;
-    
+    szForm.assign(1387, '\0');  // 1387 = 42 * 33 + 1
+
     bool white = false;
-    
+
     szForm[1386] = '\0';
-    
-    for( int i = 0; i < 33; i++ )      // 33 rows
+
+    for (int i = 0; i < 33; i++)  // 33 rows
     {
-        szForm[42 * i + 41] = '\n';      // newlines
-        if ( i % 4 == 0 )
-        {
-            for( int j = 0; j < 41; j++ )       // 41 columns
+        szForm[42 * i + 41] = '\n';  // newlines
+        if (i % 4 == 0) {
+            for (int j = 0; j < 41; j++)  // 41 columns
             {
-                if ( j % 5 == 0 )
+                if (j % 5 == 0)
                     szForm[42 * i + j] = '+';
-                else
-                {
-                    if ( i == 0  ||  i == 32 )
+                else {
+                    if (i == 0 || i == 32)
                         szForm[42 * i + j] = ChessMove::szlcLetters[j / 5];
                     else
                         szForm[42 * i + j] = '-';
                 }
             }
-        } else if ( i % 2 == 0 ) {
-            for( int j = 0; j < 41; j++ )
-            {
-                if ( j % 5 == 0 )
-                {
-                    if ( j == 0  ||  j == 40 )
-                        szForm[42 * i + j] = ChessPiece::szDigits[8 - ( i / 4 )];
+        } else if (i % 2 == 0) {
+            for (int j = 0; j < 41; j++) {
+                if (j % 5 == 0) {
+                    if (j == 0 || j == 40)
+                        szForm[42 * i + j] = ChessPiece::szDigits[8 - (i / 4)];
                     else
                         szForm[42 * i + j] = '|';
-                } else if ( j % 5 == 1  ||  j % 5 == 4 ) {
-                    if ( aapGrid[7 - ( i / 4 )][j / 5] != NULL )
+                } else if (j % 5 == 1 || j % 5 == 4) {
+                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr)
                         szForm[42 * i + j] = ' ';
-                    else
-                    {
-                        white = ( i / 4 ) % 2 == 0;
-                        if ( ( j / 5 ) % 2 != 0 )
-                            white = !white;
-                        if ( white )
+                    else {
+                        white = (i / 4) % 2 == 0;
+                        if ((j / 5) % 2 != 0) white = !white;
+                        if (white)
                             szForm[42 * i + j] = 'X';
                         else
                             szForm[42 * i + j] = ' ';
                     }
                 } else {
-                    if ( aapGrid[7 - ( i / 4 )][j / 5] != NULL )
-                    {
-                        if ( j % 5 == 2 )
-                            szForm[42 * i + j] = *((aapGrid[7 - ( i / 4 )][j / 5])->getID());
+                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr) {
+                        if (j % 5 == 2)
+                            szForm[42 * i + j] = *((aapGrid[7 - (i / 4)][j / 5])->getID());
                         else
-                            szForm[42 * i + j] = *((aapGrid[7 - ( i / 4 )][j / 5])->getID() + 1);
+                            szForm[42 * i + j] = *((aapGrid[7 - (i / 4)][j / 5])->getID() + 1);
                     } else {
-                        white = ( i / 4 ) % 2 == 0;
-                        if ( ( j / 5 ) % 2 != 0 )
-                            white = !white;
-                        if ( white )
+                        white = (i / 4) % 2 == 0;
+                        if ((j / 5) % 2 != 0) white = !white;
+                        if (white)
                             szForm[42 * i + j] = 'X';
                         else
                             szForm[42 * i + j] = ' ';
@@ -1314,31 +1094,26 @@ const char * ChessBoard::toString()
                 }
             }
         } else {
-            for( int j = 0; j < 41; j++ )
-            {
-                if ( j % 5 == 0 )
-                {
-                    if ( j == 0  ||  j == 40 )
-                        szForm[42 * i + j] = ChessPiece::szDigits[8 - ( i / 4 )];
+            for (int j = 0; j < 41; j++) {
+                if (j % 5 == 0) {
+                    if (j == 0 || j == 40)
+                        szForm[42 * i + j] = ChessPiece::szDigits[8 - (i / 4)];
                     else
                         szForm[42 * i + j] = '|';
-                } else if ( j % 5 == 1  ||  j % 5 == 4 ) {
-                    white = ( i / 4 ) % 2 == 0;
-                    if ( ( j / 5 ) % 2 != 0 )
-                        white = !white;
-                    if ( white )
+                } else if (j % 5 == 1 || j % 5 == 4) {
+                    white = (i / 4) % 2 == 0;
+                    if ((j / 5) % 2 != 0) white = !white;
+                    if (white)
                         szForm[42 * i + j] = 'X';
                     else
                         szForm[42 * i + j] = ' ';
                 } else {
-                    if ( aapGrid[7 - ( i / 4)][j / 5] != NULL )
+                    if (aapGrid[7 - (i / 4)][j / 5] != nullptr)
                         szForm[42 * i + j] = ' ';
-                    else
-                    {
-                        white = ( i / 4 ) % 2 == 0;
-                        if ( ( j / 5 ) % 2 != 0 )
-                            white = !white;
-                        if ( white )
+                    else {
+                        white = (i / 4) % 2 == 0;
+                        if ((j / 5) % 2 != 0) white = !white;
+                        if (white)
                             szForm[42 * i + j] = 'X';
                         else
                             szForm[42 * i + j] = ' ';
@@ -1347,52 +1122,47 @@ const char * ChessBoard::toString()
             }
         }
     }
-    return szForm;
+    return szForm.c_str();
 }
 
-ChessPiece * ChessBoard::getMoveablePiece( int x, int y )
-{
-    if ( x >= 0  &&  x <= 7  &&  y >= 0  &&  y <= 7 )
+ChessPiece* ChessBoard::getMoveablePiece(int x, int y) {
+    if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
         return aapGrid[x][y];
     else
-        return NULL;
+        return nullptr;
 }
 
-ChessPiece * ChessBoard::movePiece( ChessMove move )
-{
-    if ( !move.isEnd()  &&  aapGrid[move.getStartX()][move.getStartY()] != NULL )
-    {
-       ChessPiece * temp = aapGrid[move.getEndX()][move.getEndY()]; 
-       aapGrid[move.getEndX()][move.getEndY()] = aapGrid[move.getStartX()][move.getStartY()];   // replaces destination
-       aapGrid[move.getStartX()][move.getStartY()] = NULL;                                      // leaves behind nothing
-       return temp;
+ChessPiece* ChessBoard::movePiece(ChessMove move) {
+    if (!move.isEnd() && aapGrid[move.getStartX()][move.getStartY()] != nullptr) {
+        ChessPiece* temp = aapGrid[move.getEndX()][move.getEndY()];
+        aapGrid[move.getEndX()][move.getEndY()] =
+            aapGrid[move.getStartX()][move.getStartY()];        // replaces destination
+        aapGrid[move.getStartX()][move.getStartY()] = nullptr;  // leaves behind nothing
+        return temp;
     } else
-        return NULL;
+        return nullptr;
 }
 
-const ChessPiece * ChessBoard::getPiece( int x, int y ) const
-{
-    if ( x >= 0  &&  x <= 7  &&  y >= 0  &&  y <= 7 )
+const ChessPiece* ChessBoard::getPiece(int x, int y) const {
+    if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
         return aapGrid[x][y];
     else
-        return NULL;
+        return nullptr;
 }
 
-bool ChessBoard::checkCheck( bool isW ) const
-{
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( aapGrid[i][j] != NULL  &&  (aapGrid[i][j])->getType() == KING  &&  (aapGrid[i][j])->getWhite() == isW )
-            {
-                const King * piece = dynamic_cast<const King *>(getPiece( i, j ));
-                if ( piece  &&  piece->inCheck() )
+bool ChessBoard::checkCheck(bool isW) const {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (aapGrid[i][j] != nullptr && (aapGrid[i][j])->getType() == KING &&
+                (aapGrid[i][j])->getWhite() == isW) {
+                const King* piece = dynamic_cast<const King*>(getPiece(i, j));
+                if (piece && piece->inCheck())
                     return true;
-                else if ( piece )
+                else if (piece)
                     return false;
                 else
-                    return true;        // dynamic_cast failed: king pointer is wrong type; treat as error (in check)
+                    return true;  // dynamic_cast failed: king pointer is wrong type; treat as error
+                                  // (in check)
             }
         }
     }
@@ -1406,25 +1176,20 @@ bool ChessBoard::checkCheck( bool isW ) const
 }
 
 ///////////
-//CHESSGAME
+// CHESSGAME
 
-ChessGame::ChessGame():
-rulesOn(true), whiteTurn(true), board(ChessBoard())
-{}
+ChessGame::ChessGame() : rulesOn(true), whiteTurn(true), board(ChessBoard()) {}
 
-void ChessGame::setRules( bool on ) { rulesOn = on; }
+void ChessGame::setRules(bool on) { rulesOn = on; }
 bool ChessGame::getRules() const { return rulesOn; }
 
 ChessGame::~ChessGame() {}
 
-bool ChessGame::checkmate( bool white ) const
-{
-    if ( !board.checkCheck( white ) )
-        return false;
-    
-    ChessMove * moves = getMoves( white );
-    if ( moves  &&  moves->isEnd() )
-    {
+bool ChessGame::checkmate(bool white) const {
+    if (!board.checkCheck(white)) return false;
+
+    ChessMove* moves = getMoves(white);
+    if (moves && moves->isEnd()) {
         delete[] moves;
         return true;
     } else {
@@ -1433,14 +1198,11 @@ bool ChessGame::checkmate( bool white ) const
     }
 }
 
-bool ChessGame::stalemate( bool turn ) const
-{
-    if ( board.checkCheck( turn ) )
-        return false;
-    
-    ChessMove * moves = getMoves( turn );
-    if ( moves  &&  moves->isEnd() )
-    {
+bool ChessGame::stalemate(bool turn) const {
+    if (board.checkCheck(turn)) return false;
+
+    ChessMove* moves = getMoves(turn);
+    if (moves && moves->isEnd()) {
         delete[] moves;
         return true;
     } else {
@@ -1449,96 +1211,77 @@ bool ChessGame::stalemate( bool turn ) const
     }
 }
 
-ChessMove * ChessGame::getMoves( bool white ) const
-{
+ChessMove* ChessGame::getMoves(bool white) const {
     int num = 0;
-    for( int i = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( board.getPiece( i, j ) != NULL  &&  board.getPiece( i, j )->getWhite() == white )
-                num++;
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (board.getPiece(i, j) != nullptr && board.getPiece(i, j)->getWhite() == white) num++;
         }
     }
-    
-    if ( num == 0 )
-        return NULL;
-    
-    ChessMove ** moveSets = new ChessMove* [num];
-    for( int i = 0, k = 0; i < 8; i++ )
-    {
-        for( int j = 0; j < 8; j++ )
-        {
-            if ( board.getPiece( i, j ) != NULL  &&  board.getPiece( i, j )->getWhite() == white )
-            {
-                moveSets[k] = board.getPiece( i, j )->getMoves();
+
+    if (num == 0) return nullptr;
+
+    ChessMove** moveSets = new ChessMove*[num];
+    for (int i = 0, k = 0; i < 8; i++) {
+        for (int j = 0; j < 8; j++) {
+            if (board.getPiece(i, j) != nullptr && board.getPiece(i, j)->getWhite() == white) {
+                moveSets[k] = board.getPiece(i, j)->getMoves();
                 k++;
             }
         }
     }
-    
+
     int numMoves = 0;
-    for( int i = 0; i < num; i++ )
-    {
-        numMoves += ChessMove::length( moveSets[i] );
+    for (int i = 0; i < num; i++) {
+        numMoves += ChessMove::length(moveSets[i]);
     }
-    
-    if ( numMoves == 0 )
-    {
-        ChessMove * ret = new ChessMove[1];
+
+    if (numMoves == 0) {
+        ChessMove* ret = new ChessMove[1];
         ret[0] = ChessMove::end;
         return ret;
     }
-    
-    ChessMove * ret = new ChessMove[numMoves + 1];
+
+    ChessMove* ret = new ChessMove[numMoves + 1];
     ret[numMoves] = ChessMove::end;
-    
-    ChessMove::copy( ret, moveSets[0] );
-    
-    for( int i = 1; i < num; i++ )
-    {
-        ChessMove::concat( ret, moveSets[i] );
+
+    ChessMove::copy(ret, moveSets[0]);
+
+    for (int i = 1; i < num; i++) {
+        ChessMove::concat(ret, moveSets[i]);
     }
-    
-    for( int i = 0; i < num; i++ )
-    {
+
+    for (int i = 0; i < num; i++) {
         delete[] moveSets[i];
-        moveSets[i] = NULL;
+        moveSets[i] = nullptr;
     }
     delete[] moveSets;
-    moveSets = NULL;
-    
+    moveSets = nullptr;
+
     return ret;
 }
 
 bool ChessGame::getTurn() const { return whiteTurn; }
 
-bool ChessGame::makeMove( const ChessMove & cm )
-{
-    if ( rulesOn )
-    {
-        ChessPiece * piece = board.getMoveablePiece( cm.getStartX(), cm.getStartY() );
-        if ( piece == NULL  ||  piece->getWhite() != whiteTurn )
-            return false;
-        bool b = piece->move( cm.getEndX(), cm.getEndY() );
-        if ( b )
-        {
+bool ChessGame::makeMove(const ChessMove& cm) {
+    if (rulesOn) {
+        ChessPiece* piece = board.getMoveablePiece(cm.getStartX(), cm.getStartY());
+        if (piece == nullptr || piece->getWhite() != whiteTurn) return false;
+        bool b = piece->move(cm.getEndX(), cm.getEndY());
+        if (b) {
             whiteTurn = !whiteTurn;
             // Clear en passant flags for the side whose turn it now is.
             // After the flip, whiteTurn is the color that did NOT just move —
             // their en passant window (set when they double-advanced last turn)
             // has now expired because the opponent completed a move.
-            for( int i = 0; i < 8; i++ )
-            {
-                for( int j = 0; j < 8; j++ )
-                {
-                    if ( board.getPiece( i, j ) != NULL  &&  board.getPiece( i, j )->getWhite() == whiteTurn )
-                    {
-                        ChessPiece * piece = board.getMoveablePiece( i, j );
-                        if ( piece->getType() == PAWN )
-                        {
-                            Pawn * pawn = dynamic_cast<Pawn *>(piece);
-                            pawn->setEnPassant( false );
+            for (int i = 0; i < 8; i++) {
+                for (int j = 0; j < 8; j++) {
+                    if (board.getPiece(i, j) != nullptr &&
+                        board.getPiece(i, j)->getWhite() == whiteTurn) {
+                        ChessPiece* piece = board.getMoveablePiece(i, j);
+                        if (piece->getType() == PAWN) {
+                            Pawn* pawn = dynamic_cast<Pawn*>(piece);
+                            pawn->setEnPassant(false);
                         }
                     }
                 }
@@ -1546,28 +1289,24 @@ bool ChessGame::makeMove( const ChessMove & cm )
         }
         return b;
     } else {
-        ChessPiece * piece = board.movePiece( cm );
+        ChessPiece* piece = board.movePiece(cm);
         delete piece;
-        piece = NULL;
+        piece = nullptr;
         return true;
     }
 }
 
-const char * ChessGame::getBoard() { return board.toString(); }
+const char* ChessGame::getBoard() { return board.toString(); }
 
-const ChessPiece * ChessGame::getPiece( int x, int y ) const { return board.getPiece( x, y ); }
+const ChessPiece* ChessGame::getPiece(int x, int y) const { return board.getPiece(x, y); }
 
-void ChessGame::setPiece( int x, int y, ChessPiece * piece )
-{
-    if ( rulesOn )
-        return;
-    
-    if ( x < 0  ||  x > 7  ||  y < 0  ||  y > 7 )
-        return;
-    
+void ChessGame::setPiece(int x, int y, ChessPiece* piece) {
+    if (rulesOn) return;
+
+    if (x < 0 || x > 7 || y < 0 || y > 7) return;
+
     delete board.aapGrid[x][y];
     board.aapGrid[x][y] = piece;
 }
 
-ChessBoard * ChessGame::getPieceBoard() { return &board; }
-
+ChessBoard* ChessGame::getPieceBoard() { return &board; }

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -2,40 +2,32 @@
 // the header file for the chess classes which ?
 
 /*                                                                                                 1
-         1         2         3         4         5         6         7         8         9         0         1         2
+         1         2         3         4         5         6         7         8         9         0
+1         2
 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901
 */
 
 #ifndef _CHESS_H_
- #define _CHESS_H_
+#define _CHESS_H_
 
-#include <string.h>
-
-#ifdef NULL
- #if (NULL != 0 )
-  #warning NULL set to a value other than 0
- #endif
-#endif
-
-#ifndef NULL
- #define NULL 0
-#endif
+#include <cstring>
+#include <string>
 
 ///////////
-//CONSTANTS
+// CONSTANTS
 const bool WHITE = true;
 const bool BLACK = false;
 
 /////////////////////
-//DATA TYPES DECLARED
+// DATA TYPES DECLARED
 
-class ChessPiece;    //ADT
- class Pawn;
- class Rook;
- class Knight;
- class Bishop;
- class King;
- class Queen;
+class ChessPiece;  // ADT
+class Pawn;
+class Rook;
+class Knight;
+class Bishop;
+class King;
+class Queen;
 
 class ChessBoard;
 class ChessMove;
@@ -49,7 +41,7 @@ class ChessGame;
 enum PieceType { PAWN, ROOK, KNIGHT, BISHOP, KING, QUEEN };
 
 ///////////////////////
-//CLASS HEADERS IN FULL
+// CLASS HEADERS IN FULL
 
 /**
  * Abstract base class for all chess pieces.
@@ -59,10 +51,10 @@ enum PieceType { PAWN, ROOK, KNIGHT, BISHOP, KING, QUEEN };
  *
  * Piece ID string (szID): [color W/B][type P/R/N/B/K/Q][side K/Q][index digit]
  */
-class ChessPiece    // ADT
+class ChessPiece  // ADT
 {
- public:
-    ChessPiece( bool isW, bool isKS, ChessBoard * b, int i = 0 );
+   public:
+    ChessPiece(bool isW, bool isKS, ChessBoard* b, int i = 0);
     virtual ~ChessPiece();
     bool getWhite() const;
     bool getKingSide() const;
@@ -70,7 +62,7 @@ class ChessPiece    // ADT
     // Position is not cached; each call scans the full 8x8 board (O(64)).
     int getPosX() const;
     int getPosY() const;
-    const char * getID() const;
+    const char* getID() const;
 
     /**
      * Returns true if this piece can legally move to (x, y).
@@ -96,14 +88,14 @@ class ChessPiece    // ADT
      *     the enemy piece geometrically reaches the king, not whether doing so
      *     would expose the enemy's own king.
      */
-    virtual bool canMove( int x, int y, bool chkchk = true ) const = 0;
+    virtual bool canMove(int x, int y, bool chkchk = true) const = 0;
 
     /**
      * Returns a heap-allocated, ChessMove::end-terminated array of all legal
      * moves for this piece. The caller is responsible for delete[]-ing it.
      */
-    virtual ChessMove * getMoves() const = 0;
-    virtual bool move( int x, int y );
+    virtual ChessMove* getMoves() const = 0;
+    virtual bool move(int x, int y);
     virtual PieceType getType() const = 0;
 
     virtual double getValue();
@@ -113,109 +105,105 @@ class ChessPiece    // ADT
 
     friend class ChessBoard;
 
- protected:
+   protected:
     const bool isWhite;
     const bool isKingSide;
     char szID[4 + 1];
-    ChessBoard * board;
+    ChessBoard* board;
     const int index;
 
     // Virtual functions cannot be friended directly. These non-virtual
     // forwarding methods give piece subclasses access to ChessBoard's private
     // movePiece, getMoveablePiece, and setPiece methods.
-    ChessPiece * f_movePiece( ChessBoard & cb, ChessMove move ) const;
-    ChessPiece * f_getMoveablePiece( ChessBoard & cb, int x, int y ) const;
-    ChessPiece * f_setPiece( ChessBoard & cb, int x, int y, ChessPiece * piece ) const;
+    ChessPiece* f_movePiece(ChessBoard& cb, ChessMove move) const;
+    ChessPiece* f_getMoveablePiece(ChessBoard& cb, int x, int y) const;
+    ChessPiece* f_setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
 };
 
-class Pawn : public ChessPiece
-{
- public:
-    Pawn( bool isW, bool isKS, ChessBoard * b, int i );
-    ~Pawn();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
-    bool getMoved () const;
+class Pawn : public ChessPiece {
+   public:
+    Pawn(bool isW, bool isKS, ChessBoard* b, int i);
+    ~Pawn() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
+    bool getMoved() const;
     bool getEnPassant() const;
-    void setEnPassant( bool b );
-    bool move( int x, int y );
-    PieceType getType() const;
- private:
+    void setEnPassant(bool b);
+    bool move(int x, int y) override;
+    PieceType getType() const override;
+
+   private:
     bool hasMoved;
     bool enPassant;
 };
 
-class Rook : public ChessPiece
-{
- public:
-    Rook( bool isW, bool isKS, ChessBoard * b, int i = 0 );
-    ~Rook();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
+class Rook : public ChessPiece {
+   public:
+    Rook(bool isW, bool isKS, ChessBoard* b, int i = 0);
+    ~Rook() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
     bool getMoved() const;
-    bool move( int x, int y );
+    bool move(int x, int y) override;
     void markMoved();
-    PieceType getType() const;
- private:
+    PieceType getType() const override;
+
+   private:
     bool hasMoved;
 };
 
-class Knight : public ChessPiece
-{
- public:
-    Knight( bool isW, bool isKS, ChessBoard * b, int i = 0 );
-    ~Knight();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
-    PieceType getType() const;
+class Knight : public ChessPiece {
+   public:
+    Knight(bool isW, bool isKS, ChessBoard* b, int i = 0);
+    ~Knight() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
+    PieceType getType() const override;
     const static int xOffsets[8];
     const static int yOffsets[8];
 };
 
-class Bishop : public ChessPiece
-{
- public:
-    Bishop( bool isW, bool isKS, ChessBoard * b, int i = 0 );
-    ~Bishop();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
-    PieceType getType() const;
+class Bishop : public ChessPiece {
+   public:
+    Bishop(bool isW, bool isKS, ChessBoard* b, int i = 0);
+    ~Bishop() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
+    PieceType getType() const override;
 };
 
-class King : public ChessPiece
-{
- public:
-    King( bool isW, ChessBoard * b );
-    ~King();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
+class King : public ChessPiece {
+   public:
+    King(bool isW, ChessBoard* b);
+    ~King() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
     bool getMoved() const;
-    bool move( int x, int y );
+    bool move(int x, int y) override;
     bool inCheck() const;
-    PieceType getType() const;
+    PieceType getType() const override;
     const static int xOffsets[10];
     const static int yOffsets[10];
- protected:
+
+   protected:
     bool hasMoved;
 };
 
-class Queen : public ChessPiece
-{
- public:
-    Queen( bool isW, ChessBoard * b, int i = 0, bool isKS = false );
-    ~Queen();
-    bool canMove( int x, int y, bool chkchk = true ) const;
-    ChessMove * getMoves() const;
-    PieceType getType() const;
+class Queen : public ChessPiece {
+   public:
+    Queen(bool isW, ChessBoard* b, int i = 0, bool isKS = false);
+    ~Queen() override;
+    bool canMove(int x, int y, bool chkchk = true) const override;
+    ChessMove* getMoves() const override;
+    PieceType getType() const override;
 };
- 
+
 /** Owns and manages the 8x8 grid of pieces. */
-class ChessBoard
-{
- public:
+class ChessBoard {
+   public:
     ChessBoard();
     ~ChessBoard();
-    const ChessPiece * getPiece( int x, int y ) const;
+    const ChessPiece* getPiece(int x, int y) const;
 
     /**
      * Returns true if the king of the given color is in check.
@@ -227,20 +215,24 @@ class ChessBoard
      * ChessGame::setPiece() with rules disabled — for example during pawn
      * promotion or in test setups — without placing a king.
      */
-    bool checkCheck( bool isW ) const;
+    bool checkCheck(bool isW) const;
 
-    const char * toString();
+    const char* toString();
 
     friend class ChessGame;
- private:
-    ChessPiece * aapGrid[8][8];
-    ChessPiece * movePiece( ChessMove move );
-    ChessPiece * getMoveablePiece( int x, int y );
-    friend ChessPiece * ChessPiece::f_movePiece( ChessBoard & cb, ChessMove move ) const;   // virtual functions cannot be friends; these functions
-    friend ChessPiece * ChessPiece::f_getMoveablePiece( ChessBoard & cb, int x, int y ) const;  // should allow ChessPiece to get what it needs
-    friend ChessPiece * ChessPiece::f_setPiece( ChessBoard & cb, int x, int y, ChessPiece * piece ) const;
-    
-    char * szForm;
+
+   private:
+    ChessPiece* aapGrid[8][8];
+    ChessPiece* movePiece(ChessMove move);
+    ChessPiece* getMoveablePiece(int x, int y);
+    friend ChessPiece* ChessPiece::f_movePiece(ChessBoard& cb, ChessMove move)
+        const;  // virtual functions cannot be friends; these functions
+    friend ChessPiece* ChessPiece::f_getMoveablePiece(
+        ChessBoard& cb, int x, int y) const;  // should allow ChessPiece to get what it needs
+    friend ChessPiece* ChessPiece::f_setPiece(ChessBoard& cb, int x, int y,
+                                              ChessPiece* piece) const;
+
+    std::string szForm;
 };
 
 /**
@@ -254,36 +246,36 @@ class ChessBoard
  *
  * String constructor accepts "a1-b2" or "a1b2" format.
  */
-class ChessMove
-{
- public:
+class ChessMove {
+   public:
     ChessMove();
-    ChessMove( int sX, int sY, int eX, int eY );
-    ChessMove( const char * const pszMove );
-    ChessMove( const ChessMove & rcm );
+    ChessMove(int sX, int sY, int eX, int eY);
+    ChessMove(const char* const pszMove);
+    ChessMove(const ChessMove& rcm);
     ~ChessMove();
-    ChessMove & operator=( const ChessMove & rhs );
+    ChessMove& operator=(const ChessMove& rhs);
     int getStartX() const;
     int getStartY() const;
     int getEndX() const;
     int getEndY() const;
     static const ChessMove end;
     bool isEnd() const;
-    
+
     const static char szlcLetters[8 + 1];
     const static int MAXCMLENGTH;
-    
-    static void swap( ChessMove & cm1, ChessMove & cm2 );
-    static void sort( ChessMove * acm, int size );
-    static void concat( ChessMove * acm1, const ChessMove * acm2 );
-    static int length( const ChessMove * acm );
-    static void copy( ChessMove * acm1, const ChessMove * acm2 );
-    
-    const char * toString() const;
- private:
+
+    static void swap(ChessMove& cm1, ChessMove& cm2);
+    static void sort(ChessMove* acm, int size);
+    static void concat(ChessMove* acm1, const ChessMove* acm2);
+    static int length(const ChessMove* acm);
+    static void copy(ChessMove* acm1, const ChessMove* acm2);
+
+    const char* toString() const;
+
+   private:
     short int data;
     char szForm[6];
-    void init( int sX, int sY, int eX, int eY );
+    void init(int sX, int sY, int eX, int eY);
 };
 
 /**
@@ -293,33 +285,33 @@ class ChessMove
  * Pawn promotion is intentionally handled outside this class (in Main.cpp)
  * because it requires player input to select the promoted piece type.
  */
-class ChessGame
-{
- public:
+class ChessGame {
+   public:
     ChessGame();
     ~ChessGame();
 
-    void setRules( bool on );
+    void setRules(bool on);
     bool getRules() const;
-    
-    bool checkmate( bool white ) const;
-    bool stalemate( bool turn ) const;
-    
-    ChessMove * getMoves( bool white ) const;
-    
-    bool makeMove( const ChessMove & cm );
-    
-    const char * getBoard();
-    const ChessPiece * getPiece( int x, int y ) const;
-    void setPiece( int x, int y, ChessPiece * piece );
-    
+
+    bool checkmate(bool white) const;
+    bool stalemate(bool turn) const;
+
+    ChessMove* getMoves(bool white) const;
+
+    bool makeMove(const ChessMove& cm);
+
+    const char* getBoard();
+    const ChessPiece* getPiece(int x, int y) const;
+    void setPiece(int x, int y, ChessPiece* piece);
+
     bool getTurn() const;
-    
-    ChessBoard * getPieceBoard();
- private:
+
+    ChessBoard* getPieceBoard();
+
+   private:
     bool rulesOn;
     bool whiteTurn;
     ChessBoard board;
 };
 
-#endif //def _CHESS_H
+#endif  // def _CHESS_H

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -49,7 +49,7 @@ enum PieceType { PAWN, ROOK, KNIGHT, BISHOP, KING, QUEEN };
  * Pieces do not cache their board position; getPosX/getPosY scan the
  * full 8x8 grid on every call (O(64)).
  *
- * Piece ID string (szID): [color W/B][type P/R/N/B/K/Q][side K/Q][index digit]
+ * Piece ID string (id): [color W/B][type P/R/N/B/K/Q][side K/Q][index digit]
  */
 class ChessPiece  // ADT
 {
@@ -101,23 +101,23 @@ class ChessPiece  // ADT
     virtual double getValue();
     virtual int getRootValue();
 
-    const static char szDigits[10 + 1];
+    const static char digits[10 + 1];
 
     friend class ChessBoard;
 
    protected:
     const bool isWhite;
     const bool isKingSide;
-    char szID[4 + 1];
+    char id[4 + 1];
     ChessBoard* board;
     const int index;
 
     // Virtual functions cannot be friended directly. These non-virtual
     // forwarding methods give piece subclasses access to ChessBoard's private
     // movePiece, getMoveablePiece, and setPiece methods.
-    ChessPiece* f_movePiece(ChessBoard& cb, ChessMove move) const;
-    ChessPiece* f_getMoveablePiece(ChessBoard& cb, int x, int y) const;
-    ChessPiece* f_setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
+    ChessPiece* movePiece(ChessBoard& cb, ChessMove move) const;
+    ChessPiece* getMutablePiece(ChessBoard& cb, int x, int y) const;
+    ChessPiece* setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
 };
 
 class Pawn : public ChessPiece {
@@ -222,17 +222,16 @@ class ChessBoard {
     friend class ChessGame;
 
    private:
-    ChessPiece* aapGrid[8][8];
+    ChessPiece* grid[8][8];
     ChessPiece* movePiece(ChessMove move);
     ChessPiece* getMoveablePiece(int x, int y);
-    friend ChessPiece* ChessPiece::f_movePiece(ChessBoard& cb, ChessMove move)
+    friend ChessPiece* ChessPiece::movePiece(ChessBoard& cb, ChessMove move)
         const;  // virtual functions cannot be friends; these functions
-    friend ChessPiece* ChessPiece::f_getMoveablePiece(
+    friend ChessPiece* ChessPiece::getMutablePiece(
         ChessBoard& cb, int x, int y) const;  // should allow ChessPiece to get what it needs
-    friend ChessPiece* ChessPiece::f_setPiece(ChessBoard& cb, int x, int y,
-                                              ChessPiece* piece) const;
+    friend ChessPiece* ChessPiece::setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
 
-    std::string szForm;
+    std::string repr;
 };
 
 /**
@@ -250,7 +249,7 @@ class ChessMove {
    public:
     ChessMove();
     ChessMove(int sX, int sY, int eX, int eY);
-    ChessMove(const char* const pszMove);
+    ChessMove(const char* const str);
     ChessMove(const ChessMove& rcm);
     ~ChessMove();
     ChessMove& operator=(const ChessMove& rhs);
@@ -261,8 +260,8 @@ class ChessMove {
     static const ChessMove end;
     bool isEnd() const;
 
-    const static char szlcLetters[8 + 1];
-    const static int MAXCMLENGTH;
+    const static char fileLetters[8 + 1];
+    const static int maxLength;
 
     static void swap(ChessMove& cm1, ChessMove& cm2);
     static void sort(ChessMove* acm, int size);
@@ -274,7 +273,7 @@ class ChessMove {
 
    private:
     short int data;
-    char szForm[6];
+    char repr[6];
     void init(int sX, int sY, int eX, int eY);
 };
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <string>
+
 #include "chess.h"
 
 // ============================================================================
@@ -23,13 +24,10 @@ struct CustomBoard {
     CustomBoard() : b(game.getPieceBoard()) {
         game.setRules(false);
         for (int x = 0; x < 8; x++)
-            for (int y = 0; y < 8; y++)
-                game.setPiece(x, y, NULL);
+            for (int y = 0; y < 8; y++) game.setPiece(x, y, NULL);
     }
 
-    void place(int x, int y, ChessPiece* piece) {
-        game.setPiece(x, y, piece);
-    }
+    void place(int x, int y, ChessPiece* piece) { game.setPiece(x, y, piece); }
 
     // Call after placing all pieces to enable normal rules.
     void activate() { game.setRules(true); }
@@ -44,24 +42,21 @@ TEST_CASE("ChessMove: default constructor is end sentinel", "[ChessMove]") {
     REQUIRE(cm.isEnd());
 }
 
-TEST_CASE("ChessMove::end is end sentinel", "[ChessMove]") {
-    REQUIRE(ChessMove::end.isEnd());
-}
+TEST_CASE("ChessMove::end is end sentinel", "[ChessMove]") { REQUIRE(ChessMove::end.isEnd()); }
 
 TEST_CASE("ChessMove: coordinate encoding roundtrips for all squares", "[ChessMove]") {
     for (int sx = 0; sx < 8; sx++)
         for (int sy = 0; sy < 8; sy++)
             for (int ex = 0; ex < 8; ex++)
                 for (int ey = 0; ey < 8; ey++) {
-                    if (sx == 0 && sy == 0 && ex == 0 && ey == 0) continue; // isEnd()
+                    if (sx == 0 && sy == 0 && ex == 0 && ey == 0) continue;  // isEnd()
                     ChessMove cm(sx, sy, ex, ey);
                     REQUIRE(cm.getStartX() == sx);
                     REQUIRE(cm.getStartY() == sy);
                     REQUIRE(cm.getEndX() == ex);
                     REQUIRE(cm.getEndY() == ey);
                     // Non-null moves should not be end
-                    if (!(sx == ex && sy == ey))
-                        REQUIRE(!cm.isEnd());
+                    if (!(sx == ex && sy == ey)) REQUIRE(!cm.isEnd());
                 }
 }
 
@@ -97,7 +92,7 @@ TEST_CASE("ChessMove: toString format is 'a1-b2'", "[ChessMove]") {
 }
 
 TEST_CASE("ChessMove: toString for various squares", "[ChessMove]") {
-    ChessMove cm(7, 7, 0, 0); // h8-a1
+    ChessMove cm(7, 7, 0, 0);  // h8-a1
     REQUIRE(std::string(cm.toString()) == "h8-a1");
 }
 
@@ -216,8 +211,7 @@ TEST_CASE("ChessGame: pawns on ranks 1 and 6 in initial position", "[ChessGame]"
 TEST_CASE("ChessGame: middle rows empty in initial position", "[ChessGame]") {
     ChessGame game;
     for (int x = 2; x <= 5; x++)
-        for (int y = 0; y < 8; y++)
-            REQUIRE(game.getPiece(x, y) == NULL);
+        for (int y = 0; y < 8; y++) REQUIRE(game.getPiece(x, y) == NULL);
 }
 
 // ============================================================================
@@ -226,18 +220,18 @@ TEST_CASE("ChessGame: middle rows empty in initial position", "[ChessGame]") {
 
 TEST_CASE("Pawn: white pawn can advance one or two squares from starting row", "[Pawn]") {
     ChessGame game;
-    const ChessPiece* pawn = game.getPiece(1, 4); // e2
+    const ChessPiece* pawn = game.getPiece(1, 4);  // e2
     REQUIRE(pawn->getType() == PAWN);
-    REQUIRE(pawn->canMove(2, 4)); // e3 — one step
-    REQUIRE(pawn->canMove(3, 4)); // e4 — two steps
-    REQUIRE(!pawn->canMove(4, 4)); // three steps — illegal
+    REQUIRE(pawn->canMove(2, 4));   // e3 — one step
+    REQUIRE(pawn->canMove(3, 4));   // e4 — two steps
+    REQUIRE(!pawn->canMove(4, 4));  // three steps — illegal
 }
 
 TEST_CASE("Pawn: black pawn can advance one or two squares from starting row", "[Pawn]") {
     ChessGame game;
-    const ChessPiece* pawn = game.getPiece(6, 4); // e7
-    REQUIRE(pawn->canMove(5, 4)); // e6
-    REQUIRE(pawn->canMove(4, 4)); // e5
+    const ChessPiece* pawn = game.getPiece(6, 4);  // e7
+    REQUIRE(pawn->canMove(5, 4));                  // e6
+    REQUIRE(pawn->canMove(4, 4));                  // e5
     REQUIRE(!pawn->canMove(3, 4));
 }
 
@@ -250,8 +244,8 @@ TEST_CASE("Pawn: cannot advance through a blocking piece", "[Pawn]") {
     cb.activate();
 
     const ChessPiece* pawn = cb.game.getPiece(1, 4);
-    REQUIRE(!pawn->canMove(2, 4)); // blocked
-    REQUIRE(!pawn->canMove(3, 4)); // cannot jump over blocker
+    REQUIRE(!pawn->canMove(2, 4));  // blocked
+    REQUIRE(!pawn->canMove(3, 4));  // cannot jump over blocker
 }
 
 TEST_CASE("Pawn: double advance blocked if intermediate square occupied", "[Pawn]") {
@@ -280,13 +274,13 @@ TEST_CASE("Pawn: diagonal capture of enemy piece", "[Pawn]") {
     const ChessPiece* pawn = cb.game.getPiece(2, 4);
     REQUIRE(pawn->canMove(3, 5));
     REQUIRE(pawn->canMove(3, 3));
-    REQUIRE(!pawn->canMove(3, 6)); // too far
+    REQUIRE(!pawn->canMove(3, 6));  // too far
 }
 
 TEST_CASE("Pawn: cannot capture on empty diagonal", "[Pawn]") {
     ChessGame game;
     const ChessPiece* pawn = game.getPiece(1, 4);
-    REQUIRE(!pawn->canMove(2, 5)); // no piece to capture
+    REQUIRE(!pawn->canMove(2, 5));  // no piece to capture
     REQUIRE(!pawn->canMove(2, 3));
 }
 
@@ -315,29 +309,29 @@ TEST_CASE("Pawn: getMoves returns at least one move from start", "[Pawn]") {
 
 TEST_CASE("Pawn: en passant capture", "[Pawn]") {
     ChessGame game;
-    game.makeMove(ChessMove(1, 4, 3, 4)); // e2-e4 white
-    game.makeMove(ChessMove(6, 0, 5, 0)); // a7-a6 black (filler)
-    game.makeMove(ChessMove(3, 4, 4, 4)); // e4-e5 white
-    game.makeMove(ChessMove(6, 5, 4, 5)); // f7-f5 black double advance
+    game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4 white
+    game.makeMove(ChessMove(6, 0, 5, 0));  // a7-a6 black (filler)
+    game.makeMove(ChessMove(3, 4, 4, 4));  // e4-e5 white
+    game.makeMove(ChessMove(6, 5, 4, 5));  // f7-f5 black double advance
 
     const ChessPiece* pawn = game.getPiece(4, 4);
     REQUIRE(pawn != NULL);
-    REQUIRE(pawn->canMove(5, 5)); // en passant
+    REQUIRE(pawn->canMove(5, 5));  // en passant
 
     REQUIRE(game.makeMove(ChessMove(4, 4, 5, 5)));
     REQUIRE(game.getPiece(5, 5) != NULL);
     REQUIRE(game.getPiece(5, 5)->getType() == PAWN);
-    REQUIRE(game.getPiece(4, 5) == NULL); // captured pawn removed
+    REQUIRE(game.getPiece(4, 5) == NULL);  // captured pawn removed
 }
 
 TEST_CASE("Pawn: en passant opportunity expires after opponent's move", "[Pawn]") {
     ChessGame game;
-    game.makeMove(ChessMove(1, 4, 3, 4)); // e2-e4
-    game.makeMove(ChessMove(6, 0, 5, 0)); // a7-a6
-    game.makeMove(ChessMove(3, 4, 4, 4)); // e4-e5
-    game.makeMove(ChessMove(6, 5, 4, 5)); // f7-f5 (en passant opportunity)
-    game.makeMove(ChessMove(1, 0, 2, 0)); // a2-a3 white passes
-    game.makeMove(ChessMove(5, 0, 4, 0)); // a6-a5 black passes
+    game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4
+    game.makeMove(ChessMove(6, 0, 5, 0));  // a7-a6
+    game.makeMove(ChessMove(3, 4, 4, 4));  // e4-e5
+    game.makeMove(ChessMove(6, 5, 4, 5));  // f7-f5 (en passant opportunity)
+    game.makeMove(ChessMove(1, 0, 2, 0));  // a2-a3 white passes
+    game.makeMove(ChessMove(5, 0, 4, 0));  // a6-a5 black passes
 
     // En passant is no longer available
     const ChessPiece* pawn = game.getPiece(4, 4);
@@ -361,8 +355,8 @@ TEST_CASE("Rook: moves along rank and file", "[Rook]") {
     REQUIRE(rook->canMove(3, 7));
     REQUIRE(rook->canMove(0, 3));
     REQUIRE(rook->canMove(6, 3));
-    REQUIRE(!rook->canMove(4, 4)); // diagonal
-    REQUIRE(!rook->canMove(3, 3)); // null move
+    REQUIRE(!rook->canMove(4, 4));  // diagonal
+    REQUIRE(!rook->canMove(3, 3));  // null move
 }
 
 TEST_CASE("Rook: blocked by friendly piece", "[Rook]") {
@@ -375,8 +369,8 @@ TEST_CASE("Rook: blocked by friendly piece", "[Rook]") {
 
     const ChessPiece* rook = cb.game.getPiece(3, 3);
     REQUIRE(rook->canMove(3, 4));
-    REQUIRE(!rook->canMove(3, 5)); // friendly
-    REQUIRE(!rook->canMove(3, 6)); // past friendly
+    REQUIRE(!rook->canMove(3, 5));  // friendly
+    REQUIRE(!rook->canMove(3, 6));  // past friendly
 }
 
 TEST_CASE("Rook: can capture enemy, cannot jump over it", "[Rook]") {
@@ -461,7 +455,7 @@ TEST_CASE("Knight: getMoves from corner returns 2 moves", "[Knight]") {
     cb.activate();
 
     ChessMove* moves = cb.game.getPiece(0, 0)->getMoves();
-    REQUIRE(ChessMove::length(moves) == 2); // (1,2) and (2,1)
+    REQUIRE(ChessMove::length(moves) == 2);  // (1,2) and (2,1)
     delete[] moves;
 }
 
@@ -521,7 +515,7 @@ TEST_CASE("Bishop: can capture enemy piece", "[Bishop]") {
 
     const ChessPiece* bishop = cb.game.getPiece(4, 4);
     REQUIRE(bishop->canMove(6, 6));
-    REQUIRE(!bishop->canMove(7, 7)); // past enemy
+    REQUIRE(!bishop->canMove(7, 7));  // past enemy
 }
 
 // ============================================================================
@@ -547,15 +541,15 @@ TEST_CASE("King: can step to any adjacent square", "[King]") {
 TEST_CASE("King: cannot step into check", "[King]") {
     CustomBoard cb;
     cb.place(4, 4, new King(WHITE, cb.b));
-    cb.place(3, 0, new Rook(BLACK, false, cb.b)); // controls entire rank 3
+    cb.place(3, 0, new Rook(BLACK, false, cb.b));  // controls entire rank 3
     cb.place(7, 7, new King(BLACK, cb.b));
     cb.activate();
 
     const ChessPiece* king = cb.game.getPiece(4, 4);
-    REQUIRE(!king->canMove(3, 4)); // rank 3 is controlled by rook
+    REQUIRE(!king->canMove(3, 4));  // rank 3 is controlled by rook
     REQUIRE(!king->canMove(3, 3));
     REQUIRE(!king->canMove(3, 5));
-    REQUIRE(king->canMove(5, 4)); // safe
+    REQUIRE(king->canMove(5, 4));  // safe
 }
 
 TEST_CASE("King: inCheck when attacked", "[King]") {
@@ -614,10 +608,10 @@ TEST_CASE("King: cannot castle after king has moved", "[King]") {
     cb.place(7, 0, new Rook(BLACK, false, cb.b));
     cb.activate();
 
-    cb.game.makeMove(ChessMove(0, 4, 0, 3)); // king moves
-    cb.game.makeMove(ChessMove(7, 0, 6, 0)); // black filler
-    cb.game.makeMove(ChessMove(0, 3, 0, 4)); // king returns
-    cb.game.makeMove(ChessMove(6, 0, 5, 0)); // black filler
+    cb.game.makeMove(ChessMove(0, 4, 0, 3));  // king moves
+    cb.game.makeMove(ChessMove(7, 0, 6, 0));  // black filler
+    cb.game.makeMove(ChessMove(0, 3, 0, 4));  // king returns
+    cb.game.makeMove(ChessMove(6, 0, 5, 0));  // black filler
 
     REQUIRE(!cb.game.getPiece(0, 4)->canMove(0, 6));
 }
@@ -626,7 +620,7 @@ TEST_CASE("King: cannot castle through attacked square", "[King]") {
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
-    cb.place(5, 5, new Rook(BLACK, false, cb.b)); // attacks (0,5) on f-file
+    cb.place(5, 5, new Rook(BLACK, false, cb.b));  // attacks (0,5) on f-file
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.activate();
 
@@ -641,9 +635,9 @@ TEST_CASE("King: cannot castle if rook has moved", "[King]") {
     cb.place(7, 0, new Rook(BLACK, false, cb.b));
     cb.activate();
 
-    cb.game.makeMove(ChessMove(0, 7, 0, 6)); // rook moves
+    cb.game.makeMove(ChessMove(0, 7, 0, 6));  // rook moves
     cb.game.makeMove(ChessMove(7, 0, 6, 0));
-    cb.game.makeMove(ChessMove(0, 6, 0, 7)); // rook returns
+    cb.game.makeMove(ChessMove(0, 6, 0, 7));  // rook returns
     cb.game.makeMove(ChessMove(6, 0, 5, 0));
 
     REQUIRE(!cb.game.getPiece(0, 4)->canMove(0, 6));
@@ -673,7 +667,7 @@ TEST_CASE("Queen: combines rook and bishop movement", "[Queen]") {
     REQUIRE(queen->canMove(3, 5));
     // Knight-move — illegal
     REQUIRE(!queen->canMove(5, 6));
-    REQUIRE(!queen->canMove(4, 4)); // null move
+    REQUIRE(!queen->canMove(4, 4));  // null move
 }
 
 // ============================================================================
@@ -683,15 +677,15 @@ TEST_CASE("Queen: combines rook and bishop movement", "[Queen]") {
 TEST_CASE("Check: move that exposes king is illegal", "[Check]") {
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
-    cb.place(0, 5, new Rook(WHITE, true, cb.b)); // pinned to king's rank
-    cb.place(0, 7, new Rook(BLACK, false, cb.b)); // attacks along rank 0
+    cb.place(0, 5, new Rook(WHITE, true, cb.b));   // pinned to king's rank
+    cb.place(0, 7, new Rook(BLACK, false, cb.b));  // attacks along rank 0
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.activate();
 
     // White rook at (0,5) is pinned — moving off rank 0 exposes king
     const ChessPiece* rook = cb.game.getPiece(0, 5);
-    REQUIRE(!rook->canMove(1, 5)); // reveals attack on king
-    REQUIRE(rook->canMove(0, 6));  // stays on rank 0, king safe
+    REQUIRE(!rook->canMove(1, 5));  // reveals attack on king
+    REQUIRE(rook->canMove(0, 6));   // stays on rank 0, king safe
 }
 
 TEST_CASE("Check: checkCheck returns true when king is in check", "[Check]") {
@@ -714,10 +708,10 @@ TEST_CASE("Check: checkCheck returns true when king is in check", "[Check]") {
 TEST_CASE("Checkmate: fool's mate", "[ChessGame]") {
     ChessGame game;
     // 1. f3 e5 2. g4 Qh4#
-    REQUIRE(game.makeMove(ChessMove(1, 5, 2, 5))); // f3
-    REQUIRE(game.makeMove(ChessMove(6, 4, 4, 4))); // e5
-    REQUIRE(game.makeMove(ChessMove(1, 6, 3, 6))); // g4
-    REQUIRE(game.makeMove(ChessMove(7, 3, 3, 7))); // Qh4 — checkmate
+    REQUIRE(game.makeMove(ChessMove(1, 5, 2, 5)));  // f3
+    REQUIRE(game.makeMove(ChessMove(6, 4, 4, 4)));  // e5
+    REQUIRE(game.makeMove(ChessMove(1, 6, 3, 6)));  // g4
+    REQUIRE(game.makeMove(ChessMove(7, 3, 3, 7)));  // Qh4 — checkmate
 
     REQUIRE(game.checkmate(WHITE));
     REQUIRE(!game.stalemate(WHITE));
@@ -760,13 +754,13 @@ TEST_CASE("ChessGame: turn alternates after valid moves", "[ChessGame]") {
 
 TEST_CASE("ChessGame: cannot move opponent's piece", "[ChessGame]") {
     ChessGame game;
-    REQUIRE(!game.makeMove(ChessMove(6, 4, 5, 4))); // black on white's turn
+    REQUIRE(!game.makeMove(ChessMove(6, 4, 5, 4)));  // black on white's turn
     REQUIRE(game.getTurn() == WHITE);
 }
 
 TEST_CASE("ChessGame: illegal move does not change turn", "[ChessGame]") {
     ChessGame game;
-    REQUIRE(!game.makeMove(ChessMove(1, 4, 5, 4))); // pawn cannot jump 4 rows
+    REQUIRE(!game.makeMove(ChessMove(1, 4, 5, 4)));  // pawn cannot jump 4 rows
     REQUIRE(game.getTurn() == WHITE);
 }
 


### PR DESCRIPTION
## Summary

Phase 5 of the chess modernization roadmap: mechanical code freshening with no behavior changes. All 63 tests pass.

**Language modernization:**
- `NULL` → `nullptr` throughout all three files
- Remove hand-rolled `NULL` guard from `chess.h`
- C-style headers → C++ equivalents (`<cstdio>`, `<cstring>`, `<ctime>`, `<iostream>`, `<string>`)
- Remove local `abs(int)` from `chess.cpp`; use `std::abs` from `<cstdlib>`
- Add `override` to all virtual overrides in piece subclasses — `canMove`, `getMoves`, `move`, `getType`, and all destructors
- Remove `system("PAUSE")` (Windows-only; program now just exits naturally)

**`std::string` conversions:**
- `Main.cpp` input: `char[128]` + `fgets` → `std::string` + `std::getline`; `strcmp`/`strncmp` → `==`/`.substr()`
- `ChessBoard::szForm`: heap `char*` → `std::string` member; removes manual `new`/`delete` in `toString()` and destructor

**Tooling:**
- `.clang-format`: Google-based style, `IndentWidth=4`, `ColumnLimit=100`; all source files reformatted
- `.clang-tidy`: `modernize-use-nullptr`, `modernize-use-override`, `clang-analyzer-core/cplusplus` checks
- `CMakeLists.txt`: `CMAKE_EXPORT_COMPILE_COMMANDS=ON` for clang-tidy
- CI: clang-tidy step added to `build-and-test` job with `--warnings-as-errors='*'`

## Test plan
- [ ] CI build-and-test job passes (build + test + clang-tidy)
- [ ] CI coverage job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)