### PR TITLE
chess: vector<ChessMove> + promotion encapsulation (baseline step 6b)

### DIFF
--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -5,12 +5,12 @@
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "chess.h"
 
-void printDelete(char* sz);
 void printMoves(bool color, const ChessGame& game);
-void printMoveList(const ChessMove* moves);
+void printMoveList(const std::vector<ChessMove>& moves);
 // TODO: complete algebraic notation parsing (Phase 6)
 // ChessMove parseAlgMove( const char * szMove, const ChessBoard & board );
 // int stdMoves( const char * szMove, const ChessBoard & board );
@@ -20,9 +20,6 @@ int main(int argc, char* argv[]) {
     bool print = true;
     ChessGame game = ChessGame();
     std::string input;
-
-    int blackProms = 0;  // promotions
-    int whiteProms = 0;
 
     printf("Chess Version 1.0\n\n");
     printf(
@@ -70,96 +67,22 @@ int main(int argc, char* argv[]) {
             int x = input[7] - '1';
             int y = input[6] - 'a';
             if (game.getPiece(x, y) != nullptr) {
-                ChessMove* moves = game.getPiece(x, y)->getMoves();
+                auto moves = game.getPiece(x, y)->getMoves();
                 printMoveList(moves);
                 printf("\n");
-                delete[] moves;
             }
         } else if (input == "rand") {
-            ChessMove* moves = game.getMoves(game.getTurn());
-            int l = ChessMove::length(moves);
-            int move;
+            auto moves = game.getMoves(game.getTurn());
+            int l = (int)moves.size();
             if (l != 0) {
-                move = rand() % l;
+                int move = rand() % l;
                 game.makeMove(moves[move]);
                 print = true;
-                if ((moves[move].getEndX() == 0 || moves[move].getEndX() == 7) &&  // pawn promotion
-                    game.getPiece(moves[move].getEndX(), moves[move].getEndY())->getType() ==
-                        PAWN) {
-                    ChessPiece* piece = nullptr;
-                    bool kingSide = false;
-                    if (moves[move].getEndY() > 3) kingSide = true;
-
-                    int index = 0;
-                    if (game.getTurn()) {
-                        index = blackProms;
-                        blackProms++;
-                    } else {
-                        index = whiteProms;
-                        whiteProms++;
-                    }
-
-                    piece = new Queen(!game.getTurn(), game.getPieceBoard(), index, kingSide);
-                    game.setRules(false);
-                    game.setPiece(moves[move].getEndX(), moves[move].getEndY(), piece);
-                    game.setRules(true);
-                }
             }
-            delete[] moves;
         } else {
             ChessMove move = ChessMove(input.c_str());
             if (game.makeMove(move)) {
                 print = true;
-                if ((move.getEndX() == 0 || move.getEndX() == 7) &&
-                    game.getPiece(move.getEndX(), move.getEndY())->getType() == PAWN) {
-                    char pieceType = '\0';
-                    ChessPiece* piece = nullptr;
-                    bool kingSide = false;
-                    if (move.getEndY() > 3) kingSide = true;
-
-                    int index = 0;
-                    if (game.getTurn()) {
-                        index = blackProms;
-                        blackProms++;
-                    } else {
-                        index = whiteProms;
-                        whiteProms++;
-                    }
-
-                    printf("You have moved a pawn to the end of the board!\n");
-                    printf("What do you want to promote it to? (Q, R, N, B)\n");
-                    scanf("%c", &pieceType);
-                    switch (pieceType) {
-                        case 'R':
-                        case 'r': {
-                            piece =
-                                new Rook(!game.getTurn(), kingSide, game.getPieceBoard(), index);
-                            break;
-                        }
-                        case 'N':
-                        case 'n': {
-                            piece =
-                                new Knight(!game.getTurn(), kingSide, game.getPieceBoard(), index);
-                            break;
-                        }
-                        case 'B':
-                        case 'b': {
-                            piece =
-                                new Bishop(!game.getTurn(), kingSide, game.getPieceBoard(), index);
-                            break;
-                        }
-                        case 'Q':
-                        case 'q':
-                        default: {
-                            piece =
-                                new Queen(!game.getTurn(), game.getPieceBoard(), index, kingSide);
-                            break;
-                        }
-                    }
-                    game.setRules(false);
-                    game.setPiece(move.getEndX(), move.getEndY(), piece);
-                    game.setRules(true);
-                }
             }
         }
     }
@@ -167,21 +90,14 @@ int main(int argc, char* argv[]) {
     return 0;
 }
 
-void printDelete(char* sz) {
-    printf("%s", sz);
-    delete[] sz;
-}
-
 void printMoves(bool color, const ChessGame& game) {
-    ChessMove* moves = game.getMoves(color);
+    auto moves = game.getMoves(color);
     printMoveList(moves);
-    delete[] moves;
 }
 
-void printMoveList(const ChessMove* moves) {
-    int l = ChessMove::length(moves);
-    for (int i = 0; i < l; i++) {
-        printf("%s\n", moves[i].toString());
+void printMoveList(const std::vector<ChessMove>& moves) {
+    for (const auto& m : moves) {
+        printf("%s\n", m.toString());
     }
 }
 

--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -81,6 +81,26 @@ int main(int argc, char* argv[]) {
             }
         } else {
             ChessMove move = ChessMove(input.c_str());
+            // Temporary: if a pawn is moving to the back rank, ask for the
+            // promotion piece. Will be superseded by the algebraic notation
+            // parser in Phase 6.
+            const ChessPiece* piece = game.getPiece(move.getStartX(), move.getStartY());
+            if (piece != nullptr && piece->getType() == PAWN) {
+                int endRank = move.getEndX();
+                bool isPromoRank = (piece->getWhite() == WHITE) ? endRank == 7 : endRank == 0;
+                if (isPromoRank) {
+                    printf("Promote to? (q=queen, r=rook, b=bishop, n=knight): ");
+                    std::string promo;
+                    if (std::getline(std::cin, promo)) {
+                        PieceType pt = QUEEN;  // default to queen
+                        if (promo == "r") pt = ROOK;
+                        else if (promo == "b") pt = BISHOP;
+                        else if (promo == "n") pt = KNIGHT;
+                        move = ChessMove(move.getStartX(), move.getStartY(), endRank,
+                                         move.getEndY(), pt);
+                    }
+                }
+            }
             if (game.makeMove(move)) {
                 print = true;
             }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1071,21 +1071,21 @@ std::vector<ChessMove> ChessGame::getMoves(bool white) const {
     return all;
 }
 
-ChessPiece* ChessGame::makePiece(PieceType type, bool white, int y, ChessBoard* b) {
+ChessPiece* ChessGame::makePiece(PieceType type, bool white, int y) {
     bool ks = (y > 3);
     int idx = white ? whiteProms : blackProms;
     switch (type) {
         case QUEEN:
-            return new Queen(white, b, idx, ks);
+            return new Queen(white, &board, idx, ks);
         case ROOK:
-            return new Rook(white, ks, b, idx);
+            return new Rook(white, ks, &board, idx);
         case KNIGHT:
-            return new Knight(white, ks, b, idx);
+            return new Knight(white, ks, &board, idx);
         case BISHOP:
-            return new Bishop(white, ks, b, idx);
+            return new Bishop(white, ks, &board, idx);
         default:
-            assert(false);
-            return nullptr;
+            fprintf(stderr, "makePiece: invalid promotion type %d\n", static_cast<int>(type));
+            std::abort();
     }
 }
 
@@ -1104,7 +1104,7 @@ bool ChessGame::makeMove(const ChessMove& cm) {
             if (cm.getPromotion() != PAWN) {
                 int endX = cm.getEndX(), endY = cm.getEndY();
                 delete board.grid[endX][endY];
-                board.grid[endX][endY] = makePiece(cm.getPromotion(), movedColor, endY, &board);
+                board.grid[endX][endY] = makePiece(cm.getPromotion(), movedColor, endY);
                 if (movedColor) whiteProms++;
                 else blackProms++;
             }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1099,11 +1099,12 @@ bool ChessGame::makeMove(const ChessMove& cm) {
         if (b) {
             bool movedColor = whiteTurn;  // capture before flip
             // Handle pawn promotion: replace pawn with requested piece type.
+            // Write directly to board.grid (ChessGame is a friend of ChessBoard)
+            // rather than routing through setPiece() to avoid the rulesOn guard.
             if (cm.getPromotion() != PAWN) {
                 int endX = cm.getEndX(), endY = cm.getEndY();
-                rulesOn = false;
-                setPiece(endX, endY, makePiece(cm.getPromotion(), movedColor, endY, &board));
-                rulesOn = true;
+                delete board.grid[endX][endY];
+                board.grid[endX][endY] = makePiece(cm.getPromotion(), movedColor, endY, &board);
                 if (movedColor) whiteProms++;
                 else blackProms++;
             }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -99,40 +99,6 @@ void ChessMove::swap(ChessMove& cm1, ChessMove& cm2) {
     cm2 = temp;
 }
 
-void ChessMove::sort(ChessMove* acm, int size) {
-    for (int j, i = 0; i < size - 1; i++)  // sort the ::ends to the end ( ::end like \0 in string )
-    {
-        if (acm[i].isEnd()) {
-            for (j = i + 1; j < size; j++) {
-                if (!acm[j].isEnd()) {
-                    ChessMove::swap(acm[i], acm[j]);
-                    break;
-                }
-            }
-            if (j == size)  // nothing to swap with?
-                break;
-        }
-    }
-}
-
-int ChessMove::length(ChessMove const* cm) {
-    if (cm == nullptr) return 0;
-    int l;
-    for (l = 0; !(cm[l].isEnd()) && l < maxLength; l++);
-    return l;
-}
-
-void ChessMove::copy(ChessMove* cm1, const ChessMove* cm2) {
-    int l = length(cm2);
-    for (int i = 0; i <= l; i++) {
-        cm1[i] = cm2[i];
-    }
-}
-
-void ChessMove::concat(ChessMove* cm1, const ChessMove* cm2) {
-    int l = length(cm1);
-    if (cm1[l].isEnd()) copy(cm1 + l, cm2);
-}
 
 const char* ChessMove::toString() const { return repr; }
 
@@ -323,41 +289,26 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* Pawn::getMoves() const {
+std::vector<ChessMove> Pawn::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    int sign = 1;
-    if (!isWhite) sign -= 2;
+    int sign = isWhite ? 1 : -1;
+    std::vector<ChessMove> ret;
 
-    ChessMove* ret = new ChessMove[4 + 1];
-    if (!ret) {
-        return nullptr;
+    if (x + sign == 0 || x + sign == 7) {
+        // Pawn reaches back rank — emit one move per promotion type per direction
+        for (PieceType p : {QUEEN, ROOK, KNIGHT, BISHOP}) {
+            if (canMove(x + sign, y)) ret.emplace_back(x, y, x + sign, y, p);
+            if (canMove(x + sign, y + 1)) ret.emplace_back(x, y, x + sign, y + 1, p);
+            if (canMove(x + sign, y - 1)) ret.emplace_back(x, y, x + sign, y - 1, p);
+        }
+    } else {
+        if (canMove(x + sign, y)) ret.emplace_back(x, y, x + sign, y);
+        if (canMove(x + 2 * sign, y)) ret.emplace_back(x, y, x + 2 * sign, y);
+        if (canMove(x + sign, y + 1)) ret.emplace_back(x, y, x + sign, y + 1);
+        if (canMove(x + sign, y - 1)) ret.emplace_back(x, y, x + sign, y - 1);
     }
-
-    ret[4] = ChessMove::end;
-
-    if (canMove(x + sign, y))
-        ret[0] = ChessMove(x, y, x + sign, y);
-    else
-        ret[0] = ChessMove::end;
-
-    if (canMove(x + 2 * sign, y))
-        ret[1] = ChessMove(x, y, x + 2 * sign, y);
-    else
-        ret[1] = ChessMove::end;
-
-    if (canMove(x + sign, y + 1))
-        ret[2] = ChessMove(x, y, x + sign, y + 1);
-    else
-        ret[2] = ChessMove::end;
-
-    if (canMove(x + sign, y - 1))
-        ret[3] = ChessMove(x, y, x + sign, y - 1);
-    else
-        ret[3] = ChessMove::end;
-
-    ChessMove::sort(ret, 5);  // sort the ::ends to the end
     return ret;
 }
 
@@ -454,35 +405,18 @@ bool Rook::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* Rook::getMoves() const {
+std::vector<ChessMove> Rook::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    ChessMove* ret = new ChessMove[14 + 1];
-    if (!ret) return nullptr;
+    std::vector<ChessMove> ret;
 
-    for (int i = 0; i < 15; i++)  // all blank to start
-    {
-        ret[i] = ChessMove::end;
-    }
+    for (int i = 0; i < 8; i++)  // moves in the same row
+        if (y != i && canMove(x, i)) ret.emplace_back(x, y, x, i);
 
-    for (int i = 0, j = 0; i < 8; i++)  // add move in the same row
-    {
-        if (y != i) {
-            if (canMove(x, i)) ret[j] = ChessMove(x, y, x, i);
-            j++;
-        }
-    }
+    for (int i = 0; i < 8; i++)  // moves in the same column
+        if (x != i && canMove(i, y)) ret.emplace_back(x, y, i, y);
 
-    for (int i = 0, j = 7; i < 8; i++)  // add moves in the same column
-    {
-        if (x != i) {
-            if (canMove(i, y)) ret[j] = ChessMove(x, y, i, y);
-            j++;
-        }
-    }
-
-    ChessMove::sort(ret, 15);
     return ret;
 }
 
@@ -543,23 +477,15 @@ bool Knight::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* Knight::getMoves() const {
+std::vector<ChessMove> Knight::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    ChessMove* ret = new ChessMove[8 + 1];
-    if (!ret) return nullptr;
-
-    for (int i = 0; i < 9; i++) {
-        ret[i] = ChessMove::end;
-    }
-
-    for (int i = 0; i < 8; i++) {
+    std::vector<ChessMove> ret;
+    for (int i = 0; i < 8; i++)
         if (canMove(x + xOffsets[i], y + yOffsets[i]))
-            ret[i] = ChessMove(x, y, x + xOffsets[i], y + yOffsets[i]);
-    }
+            ret.emplace_back(x, y, x + xOffsets[i], y + yOffsets[i]);
 
-    ChessMove::sort(ret, 9);
     return ret;
 }
 
@@ -625,47 +551,24 @@ bool Bishop::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* Bishop::getMoves() const {
+std::vector<ChessMove> Bishop::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    ChessMove* ret = new ChessMove[13 + 1];
-    if (!ret) return nullptr;
+    std::vector<ChessMove> ret;
 
-    for (int i = 0; i < 14; i++) {
-        ret[i] = ChessMove::end;
-    }
+    for (int j = 0; (x + j < 8 && y + j < 8); j++)
+        if (canMove(x + j, y + j)) ret.emplace_back(x, y, x + j, y + j);
 
-    int i = 0;
-    for (int j = 0; (x + j < 8 && y + j < 8); j++) {
-        if (canMove(x + j, y + j)) {
-            ret[i] = ChessMove(x, y, x + j, y + j);
-            i++;
-        }
-    }
+    for (int j = 0; (x - j >= 0 && y - j >= 0); j++)
+        if (canMove(x - j, y - j)) ret.emplace_back(x, y, x - j, y - j);
 
-    for (int j = 0; (x - j >= 0 && y - j >= 0); j++) {
-        if (canMove(x - j, y - j)) {
-            ret[i] = ChessMove(x, y, x - j, y - j);
-            i++;
-        }
-    }
+    for (int j = 0; (x + j < 8 && y - j >= 0); j++)
+        if (canMove(x + j, y - j)) ret.emplace_back(x, y, x + j, y - j);
 
-    for (int j = 0; (x + j < 8 && y - j >= 0); j++) {
-        if (canMove(x + j, y - j)) {
-            ret[i] = ChessMove(x, y, x + j, y - j);
-            i++;
-        }
-    }
+    for (int j = 0; (x - j >= 0 && y + j < 8); j++)
+        if (canMove(x - j, y + j)) ret.emplace_back(x, y, x - j, y + j);
 
-    for (int j = 0; (x - j >= 0 && y + j < 8); j++) {
-        if (canMove(x - j, y + j)) {
-            ret[i] = ChessMove(x, y, x - j, y + j);
-            i++;
-        }
-    }
-
-    ChessMove::sort(ret, 14);  // shouldn't be necessary; if so returns quickly.
     return ret;
 }
 
@@ -759,23 +662,15 @@ bool King::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* King::getMoves() const {
+std::vector<ChessMove> King::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    ChessMove* ret = new ChessMove[10 + 1];
-    if (!ret) return nullptr;
-
-    for (int i = 0; i < 11; i++) {
-        ret[i] = ChessMove::end;
-    }
-
-    for (int i = 0; i < 10; i++) {
+    std::vector<ChessMove> ret;
+    for (int i = 0; i < 10; i++)
         if (canMove(x + xOffsets[i], y + yOffsets[i]))
-            ret[i] = ChessMove(x, y, x + xOffsets[i], y + yOffsets[i]);
-    }
+            ret.emplace_back(x, y, x + xOffsets[i], y + yOffsets[i]);
 
-    ChessMove::sort(ret, 11);
     return ret;
 }
 
@@ -910,64 +805,30 @@ bool Queen::canMove(int x, int y, bool chkchk) const {
         return true;
 }
 
-ChessMove* Queen::getMoves() const {
+std::vector<ChessMove> Queen::getMoves() const {
     int x = getPosX();
     int y = getPosY();
 
-    ChessMove* ret = new ChessMove[27 + 1];
-    if (!ret) return nullptr;
+    std::vector<ChessMove> ret;
 
-    for (int i = 0; i < 28; i++)  // all blank to start
-    {
-        ret[i] = ChessMove::end;
-    }
+    for (int i = 0; i < 8; i++)  // same row
+        if (y != i && canMove(x, i)) ret.emplace_back(x, y, x, i);
 
-    for (int i = 0, j = 0; i < 8; i++)  // add move in the same row
-    {
-        if (y != i) {
-            if (canMove(x, i)) ret[j] = ChessMove(x, y, x, i);
-            j++;
-        }
-    }
+    for (int i = 0; i < 8; i++)  // same column
+        if (x != i && canMove(i, y)) ret.emplace_back(x, y, i, y);
 
-    for (int i = 0, j = 7; i < 8; i++)  // add moves in the same column
-    {
-        if (x != i) {
-            if (canMove(i, y)) ret[j] = ChessMove(x, y, i, y);
-            j++;
-        }
-    }
+    for (int j = 0; (x + j < 8 && y + j < 8); j++)
+        if (canMove(x + j, y + j)) ret.emplace_back(x, y, x + j, y + j);
 
-    int i = 14;
-    for (int j = 0; (x + j < 8 && y + j < 8); j++) {
-        if (canMove(x + j, y + j)) {
-            ret[i] = ChessMove(x, y, x + j, y + j);
-            i++;
-        }
-    }
+    for (int j = 0; (x - j >= 0 && y - j >= 0); j++)
+        if (canMove(x - j, y - j)) ret.emplace_back(x, y, x - j, y - j);
 
-    for (int j = 0; (x - j >= 0 && y - j >= 0); j++) {
-        if (canMove(x - j, y - j)) {
-            ret[i] = ChessMove(x, y, x - j, y - j);
-            i++;
-        }
-    }
+    for (int j = 0; (x + j < 8 && y - j >= 0); j++)
+        if (canMove(x + j, y - j)) ret.emplace_back(x, y, x + j, y - j);
 
-    for (int j = 0; (x + j < 8 && y - j >= 0); j++) {
-        if (canMove(x + j, y - j)) {
-            ret[i] = ChessMove(x, y, x + j, y - j);
-            i++;
-        }
-    }
+    for (int j = 0; (x - j >= 0 && y + j < 8); j++)
+        if (canMove(x - j, y + j)) ret.emplace_back(x, y, x - j, y + j);
 
-    for (int j = 0; (x - j >= 0 && y + j < 8); j++) {
-        if (canMove(x - j, y + j)) {
-            ret[i] = ChessMove(x, y, x - j, y + j);
-            i++;
-        }
-    }
-
-    ChessMove::sort(ret, 28);
     return ret;
 }
 
@@ -1188,78 +1049,44 @@ ChessGame::~ChessGame() {}
 
 bool ChessGame::checkmate(bool white) const {
     if (!board.checkCheck(white)) return false;
-
-    ChessMove* moves = getMoves(white);
-    if (moves && moves->isEnd()) {
-        delete[] moves;
-        return true;
-    } else {
-        delete[] moves;
-        return false;
-    }
+    return getMoves(white).empty();
 }
 
 bool ChessGame::stalemate(bool turn) const {
     if (board.checkCheck(turn)) return false;
-
-    ChessMove* moves = getMoves(turn);
-    if (moves && moves->isEnd()) {
-        delete[] moves;
-        return true;
-    } else {
-        delete[] moves;
-        return false;
-    }
+    return getMoves(turn).empty();
 }
 
-ChessMove* ChessGame::getMoves(bool white) const {
-    int num = 0;
+std::vector<ChessMove> ChessGame::getMoves(bool white) const {
+    std::vector<ChessMove> all;
     for (int i = 0; i < 8; i++) {
         for (int j = 0; j < 8; j++) {
-            if (board.getPiece(i, j) != nullptr && board.getPiece(i, j)->getWhite() == white) num++;
-        }
-    }
-
-    if (num == 0) return nullptr;
-
-    ChessMove** moveSets = new ChessMove*[num];
-    for (int i = 0, k = 0; i < 8; i++) {
-        for (int j = 0; j < 8; j++) {
-            if (board.getPiece(i, j) != nullptr && board.getPiece(i, j)->getWhite() == white) {
-                moveSets[k] = board.getPiece(i, j)->getMoves();
-                k++;
+            const ChessPiece* p = board.getPiece(i, j);
+            if (p && p->getWhite() == white) {
+                auto m = p->getMoves();
+                all.insert(all.end(), m.begin(), m.end());
             }
         }
     }
+    return all;
+}
 
-    int numMoves = 0;
-    for (int i = 0; i < num; i++) {
-        numMoves += ChessMove::length(moveSets[i]);
+ChessPiece* ChessGame::makePiece(PieceType type, bool white, int y, ChessBoard* b) {
+    bool ks = (y > 3);
+    int idx = white ? whiteProms : blackProms;
+    switch (type) {
+        case QUEEN:
+            return new Queen(white, b, idx, ks);
+        case ROOK:
+            return new Rook(white, ks, b, idx);
+        case KNIGHT:
+            return new Knight(white, ks, b, idx);
+        case BISHOP:
+            return new Bishop(white, ks, b, idx);
+        default:
+            assert(false);
+            return nullptr;
     }
-
-    if (numMoves == 0) {
-        ChessMove* ret = new ChessMove[1];
-        ret[0] = ChessMove::end;
-        return ret;
-    }
-
-    ChessMove* ret = new ChessMove[numMoves + 1];
-    ret[numMoves] = ChessMove::end;
-
-    ChessMove::copy(ret, moveSets[0]);
-
-    for (int i = 1; i < num; i++) {
-        ChessMove::concat(ret, moveSets[i]);
-    }
-
-    for (int i = 0; i < num; i++) {
-        delete[] moveSets[i];
-        moveSets[i] = nullptr;
-    }
-    delete[] moveSets;
-    moveSets = nullptr;
-
-    return ret;
 }
 
 bool ChessGame::getTurn() const { return whiteTurn; }
@@ -1270,6 +1097,16 @@ bool ChessGame::makeMove(const ChessMove& cm) {
         if (piece == nullptr || piece->getWhite() != whiteTurn) return false;
         bool b = piece->move(cm.getEndX(), cm.getEndY());
         if (b) {
+            bool movedColor = whiteTurn;  // capture before flip
+            // Handle pawn promotion: replace pawn with requested piece type.
+            if (cm.getPromotion() != PAWN) {
+                int endX = cm.getEndX(), endY = cm.getEndY();
+                rulesOn = false;
+                setPiece(endX, endY, makePiece(cm.getPromotion(), movedColor, endY, &board));
+                rulesOn = true;
+                if (movedColor) whiteProms++;
+                else blackProms++;
+            }
             whiteTurn = !whiteTurn;
             // Clear en passant flags for the side whose turn it now is.
             // After the flip, whiteTurn is the color that did NOT just move —
@@ -1279,9 +1116,9 @@ bool ChessGame::makeMove(const ChessMove& cm) {
                 for (int j = 0; j < 8; j++) {
                     if (board.getPiece(i, j) != nullptr &&
                         board.getPiece(i, j)->getWhite() == whiteTurn) {
-                        ChessPiece* piece = board.getMoveablePiece(i, j);
-                        if (piece->getType() == PAWN) {
-                            Pawn* pawn = dynamic_cast<Pawn*>(piece);
+                        ChessPiece* p = board.getMoveablePiece(i, j);
+                        if (p->getType() == PAWN) {
+                            Pawn* pawn = dynamic_cast<Pawn*>(p);
                             pawn->setEnPassant(false);
                         }
                     }
@@ -1290,9 +1127,8 @@ bool ChessGame::makeMove(const ChessMove& cm) {
         }
         return b;
     } else {
-        ChessPiece* piece = board.movePiece(cm);
-        delete piece;
-        piece = nullptr;
+        ChessPiece* displaced = board.movePiece(cm);
+        delete displaced;
         return true;
     }
 }

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <vector>
 
 ///////////
 // CONSTANTS
@@ -92,10 +93,9 @@ class ChessPiece  // ADT
     virtual bool canMove(int x, int y, bool chkchk = true) const = 0;
 
     /**
-     * Returns a heap-allocated, ChessMove::end-terminated array of all legal
-     * moves for this piece. The caller is responsible for delete[]-ing it.
+     * Returns all legal moves for this piece as a vector.
      */
-    virtual ChessMove* getMoves() const = 0;
+    virtual std::vector<ChessMove> getMoves() const = 0;
     virtual bool move(int x, int y);
     virtual PieceType getType() const = 0;
 
@@ -126,7 +126,7 @@ class Pawn : public ChessPiece {
     Pawn(bool isW, bool isKS, ChessBoard* b, int i);
     ~Pawn() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     bool getMoved() const;
     bool getEnPassant() const;
     void setEnPassant(bool b);
@@ -143,7 +143,7 @@ class Rook : public ChessPiece {
     Rook(bool isW, bool isKS, ChessBoard* b, int i = 0);
     ~Rook() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     bool getMoved() const;
     bool move(int x, int y) override;
     void markMoved();
@@ -158,7 +158,7 @@ class Knight : public ChessPiece {
     Knight(bool isW, bool isKS, ChessBoard* b, int i = 0);
     ~Knight() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     PieceType getType() const override;
     const static int xOffsets[8];
     const static int yOffsets[8];
@@ -169,7 +169,7 @@ class Bishop : public ChessPiece {
     Bishop(bool isW, bool isKS, ChessBoard* b, int i = 0);
     ~Bishop() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     PieceType getType() const override;
 };
 
@@ -178,7 +178,7 @@ class King : public ChessPiece {
     King(bool isW, ChessBoard* b);
     ~King() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     bool getMoved() const;
     bool move(int x, int y) override;
     bool inCheck() const;
@@ -195,7 +195,7 @@ class Queen : public ChessPiece {
     Queen(bool isW, ChessBoard* b, int i = 0, bool isKS = false);
     ~Queen() override;
     bool canMove(int x, int y, bool chkchk = true) const override;
-    ChessMove* getMoves() const override;
+    std::vector<ChessMove> getMoves() const override;
     PieceType getType() const override;
 };
 
@@ -268,10 +268,6 @@ class ChessMove {
     const static int maxLength;
 
     static void swap(ChessMove& cm1, ChessMove& cm2);
-    static void sort(ChessMove* acm, int size);
-    static void concat(ChessMove* acm1, const ChessMove* acm2);
-    static int length(const ChessMove* acm);
-    static void copy(ChessMove* acm1, const ChessMove* acm2);
 
     const char* toString() const;
 
@@ -285,8 +281,9 @@ class ChessMove {
  * Top-level game controller. Enforces turn order, manages en passant
  * expiry after each move, and detects checkmate/stalemate.
  *
- * Pawn promotion is intentionally handled outside this class (in Main.cpp)
- * because it requires player input to select the promoted piece type.
+ * Pawn promotion is handled inside this class via makeMove(): when a
+ * ChessMove carries a non-PAWN promotion field, the pawn is automatically
+ * replaced with the requested piece type.
  */
 class ChessGame {
    public:
@@ -299,7 +296,7 @@ class ChessGame {
     bool checkmate(bool white) const;
     bool stalemate(bool turn) const;
 
-    ChessMove* getMoves(bool white) const;
+    std::vector<ChessMove> getMoves(bool white) const;
 
     bool makeMove(const ChessMove& cm);
 
@@ -315,6 +312,9 @@ class ChessGame {
     bool rulesOn;
     bool whiteTurn;
     ChessBoard board;
+    int whiteProms = 0;
+    int blackProms = 0;
+    ChessPiece* makePiece(PieceType type, bool white, int y, ChessBoard* b);
 };
 
 #endif  // def _CHESS_H

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -314,7 +314,7 @@ class ChessGame {
     ChessBoard board;
     int whiteProms = 0;
     int blackProms = 0;
-    ChessPiece* makePiece(PieceType type, bool white, int y, ChessBoard* b);
+    ChessPiece* makePiece(PieceType type, bool white, int y);
 };
 
 #endif  // def _CHESS_H

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -803,11 +803,6 @@ TEST_CASE("Pawn: promotion to rook works", "[Pawn]") {
     REQUIRE(cb.game.getPiece(7, 3)->getType() == ROOK);
 }
 
-TEST_CASE("ChessMove: getPromotion returns PAWN for normal move", "[ChessMove]") {
-    ChessMove cm(1, 2, 3, 4);
-    REQUIRE(cm.getPromotion() == PAWN);
-}
-
 TEST_CASE("ChessMove: getPromotion returns promotion type for promotion move", "[ChessMove]") {
     ChessMove cm(6, 3, 7, 3, QUEEN);
     REQUIRE(cm.getPromotion() == QUEEN);

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -110,55 +110,6 @@ TEST_CASE("ChessMove: string constructor parses 'a1b2' (no separator)", "[ChessM
     REQUIRE(cm.getEndY() == 1);
 }
 
-TEST_CASE("ChessMove::length returns number of non-end moves", "[ChessMove]") {
-    REQUIRE(ChessMove::length(NULL) == 0);
-
-    ChessMove arr[4];
-    arr[0] = ChessMove::end;
-    REQUIRE(ChessMove::length(arr) == 0);
-
-    arr[0] = ChessMove(0, 1, 2, 3);
-    arr[1] = ChessMove(1, 0, 3, 2);
-    arr[2] = ChessMove::end;
-    REQUIRE(ChessMove::length(arr) == 2);
-}
-
-TEST_CASE("ChessMove::sort moves ends to back", "[ChessMove]") {
-    ChessMove arr[5];
-    arr[0] = ChessMove::end;
-    arr[1] = ChessMove(0, 1, 2, 3);
-    arr[2] = ChessMove::end;
-    arr[3] = ChessMove(4, 5, 6, 7);
-    arr[4] = ChessMove::end;
-
-    ChessMove::sort(arr, 5);
-
-    REQUIRE(!arr[0].isEnd());
-    REQUIRE(!arr[1].isEnd());
-    REQUIRE(arr[2].isEnd());
-}
-
-TEST_CASE("ChessMove::copy and concat", "[ChessMove]") {
-    ChessMove src[3];
-    src[0] = ChessMove(0, 1, 2, 3);
-    src[1] = ChessMove(4, 5, 6, 7);
-    src[2] = ChessMove::end;
-
-    ChessMove dst[6];
-    dst[0] = ChessMove::end;
-
-    ChessMove::copy(dst, src);
-    REQUIRE(ChessMove::length(dst) == 2);
-    REQUIRE(dst[0].getStartX() == 0);
-
-    ChessMove extra[2];
-    extra[0] = ChessMove(1, 1, 2, 2);
-    extra[1] = ChessMove::end;
-
-    ChessMove::concat(dst, extra);
-    REQUIRE(ChessMove::length(dst) == 3);
-}
-
 TEST_CASE("ChessMove: getPromotion returns PAWN for non-promotion move", "[ChessMove]") {
     ChessMove cm(1, 2, 3, 4);
     REQUIRE(cm.getPromotion() == PAWN);
@@ -192,7 +143,6 @@ TEST_CASE("ChessMove: toString includes promotion letter for promotion move", "[
     ChessMove plain(1, 2, 3, 4);
     REQUIRE(std::string(plain.toString()) == "c2-e4");
 }
-
 // ============================================================================
 // ChessBoard / ChessGame: initial position
 // ============================================================================
@@ -334,9 +284,8 @@ TEST_CASE("Pawn: makeMove advances pawn and clears source square", "[Pawn]") {
 
 TEST_CASE("Pawn: getMoves returns at least one move from start", "[Pawn]") {
     ChessGame game;
-    ChessMove* moves = game.getPiece(1, 4)->getMoves();
-    REQUIRE(ChessMove::length(moves) > 0);
-    delete[] moves;
+    auto moves = game.getPiece(1, 4)->getMoves();
+    REQUIRE(!moves.empty());
 }
 
 TEST_CASE("Pawn: en passant capture", "[Pawn]") {
@@ -425,14 +374,12 @@ TEST_CASE("Rook: getMoves covers all reachable squares from open center", "[Rook
     cb.place(7, 7, new King(BLACK, cb.b));
     cb.activate();
 
-    ChessMove* moves = cb.game.getPiece(3, 3)->getMoves();
+    auto moves = cb.game.getPiece(3, 3)->getMoves();
     // From (3,3) open board: 7 along rank + 7 along file - 2 occupied (King)
     // In practice: along x=3 (7 squares) + along y=3 (7 squares) = 14, minus
     // squares blocked by kings at (0,0) and (7,7) — those aren't on rank 3 or file 3
     // so 14 moves expected
-    int len = ChessMove::length(moves);
-    REQUIRE(len == 14);
-    delete[] moves;
+    REQUIRE((int)moves.size() == 14);
 }
 
 // ============================================================================
@@ -486,9 +433,8 @@ TEST_CASE("Knight: getMoves from corner returns 2 moves", "[Knight]") {
     cb.place(7, 7, new King(BLACK, cb.b));
     cb.activate();
 
-    ChessMove* moves = cb.game.getPiece(0, 0)->getMoves();
-    REQUIRE(ChessMove::length(moves) == 2);  // (1,2) and (2,1)
-    delete[] moves;
+    auto moves = cb.game.getPiece(0, 0)->getMoves();
+    REQUIRE((int)moves.size() == 2);  // (1,2) and (2,1)
 }
 
 // ============================================================================
@@ -796,12 +742,10 @@ TEST_CASE("ChessGame: illegal move does not change turn", "[ChessGame]") {
     REQUIRE(game.getTurn() == WHITE);
 }
 
-TEST_CASE("ChessGame: getMoves returns non-null list at start", "[ChessGame]") {
+TEST_CASE("ChessGame: getMoves returns non-empty list at start", "[ChessGame]") {
     ChessGame game;
-    ChessMove* moves = game.getMoves(WHITE);
-    REQUIRE(moves != NULL);
-    REQUIRE(ChessMove::length(moves) > 0);
-    delete[] moves;
+    auto moves = game.getMoves(WHITE);
+    REQUIRE(!moves.empty());
 }
 
 TEST_CASE("ChessGame: getPieceBoard returns valid board pointer", "[ChessGame]") {
@@ -816,4 +760,56 @@ TEST_CASE("ChessGame: rules can be toggled", "[ChessGame]") {
     REQUIRE(game.getRules() == false);
     game.setRules(true);
     REQUIRE(game.getRules() == true);
+}
+
+// ============================================================================
+// Pawn promotion
+// ============================================================================
+
+TEST_CASE("Pawn: getMoves emits 4 promotion moves at back rank", "[Pawn]") {
+    CustomBoard cb;
+    cb.place(6, 3, new Pawn(WHITE, false, cb.b, 1));  // white pawn at d7 (row 6, col 3)
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    auto moves = cb.game.getPiece(6, 3)->getMoves();
+    // 4 promotion types for the forward move
+    int promCount = 0;
+    for (const auto& m : moves)
+        if (m.getPromotion() != PAWN) promCount++;
+    REQUIRE(promCount == 4);
+}
+
+TEST_CASE("Pawn: promotion move results in correct piece type on board", "[Pawn]") {
+    CustomBoard cb;
+    cb.place(6, 3, new Pawn(WHITE, false, cb.b, 1));  // d7
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    // Make a queen-promotion move
+    REQUIRE(cb.game.makeMove(ChessMove(6, 3, 7, 3, QUEEN)));
+    REQUIRE(cb.game.getPiece(7, 3) != nullptr);
+    REQUIRE(cb.game.getPiece(7, 3)->getType() == QUEEN);
+    REQUIRE(cb.game.getPiece(6, 3) == nullptr);
+}
+
+TEST_CASE("Pawn: promotion to rook works", "[Pawn]") {
+    CustomBoard cb;
+    cb.place(6, 3, new Pawn(WHITE, false, cb.b, 1));
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    REQUIRE(cb.game.makeMove(ChessMove(6, 3, 7, 3, ROOK)));
+    REQUIRE(cb.game.getPiece(7, 3)->getType() == ROOK);
+}
+
+TEST_CASE("ChessMove: getPromotion returns PAWN for normal move", "[ChessMove]") {
+    ChessMove cm(1, 2, 3, 4);
+    REQUIRE(cm.getPromotion() == PAWN);
+}
+
+TEST_CASE("ChessMove: getPromotion returns promotion type for promotion move", "[ChessMove]") {
+    ChessMove cm(6, 3, 7, 3, QUEEN);
+    REQUIRE(cm.getPromotion() == QUEEN);
+    REQUIRE(!cm.isEnd());
 }


### PR DESCRIPTION
## Summary

- All `getMoves()` overrides now return `std::vector<ChessMove>` instead of heap-allocated, end-terminated arrays — eliminates memory management boilerplate and the `length()`/`copy()`/`concat()` static utilities.
- `ChessGame::getMoves(bool)` likewise returns a vector; `checkmate()`/`stalemate()` simplified to use `.empty()`.
- Pawn promotion is now encapsulated in the engine: `Pawn::getMoves()` emits 4 promotion moves per direction when the pawn reaches the back rank, and `ChessGame::makeMove()` detects `cm.getPromotion() != PAWN` and replaces the pawn via a new `ChessGame::makePiece()` helper.
- `Main.cpp`: removes the old promotion input/handling blocks; updates all `getMoves()` callers to use vector idioms; `printMoveList` now takes `const std::vector<ChessMove>&`.
- Removes `ChessMove::sort`, `length`, `copy`, `concat` static methods (header + implementation).

## Test plan

- [x] `cmake --build chess/build -j4 --clean-first` — clean build, no errors (only pre-existing unused argc/argv warning in main)
- [x] `./chess/build/chess_tests` — all 65 tests pass (60 existing + 5 new promotion tests)
- [ ] Review: `Pawn::getMoves()` emits exactly 4 promotion moves for a pawn at row 6 moving to row 7
- [ ] Review: `ChessGame::makeMove(ChessMove(6,3,7,3,QUEEN))` replaces pawn with Queen on board
- [ ] Review: normal (non-promotion) moves unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)