### PR TITLE
chess: unique_ptr<ChessPiece> + O(1) position caching (baseline step 6c)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -262,6 +262,9 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -375,6 +378,9 @@ bool Rook::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -447,6 +453,9 @@ bool Knight::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -521,6 +530,9 @@ bool Bishop::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -632,6 +644,9 @@ bool King::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(inCheck());
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -775,6 +790,9 @@ bool Queen::canMove(int x, int y, bool chkchk) const {
         auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
         (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        // temp->posX/posY is stale while temp is off the board, but
+        // checkCheck only reads pieces via the grid so this is safe.
+        // place() (called by setPiece) restores the cache here.
         setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
@@ -953,6 +971,7 @@ ChessPiece* ChessBoard::getMoveablePiece(int x, int y) {
 }
 
 void ChessBoard::place(int x, int y, std::unique_ptr<ChessPiece> p) {
+    assert(x >= 0 && x <= 7 && y >= 0 && y <= 7);
     if (p) {
         p->posX = x;
         p->posY = y;
@@ -966,11 +985,12 @@ std::unique_ptr<ChessPiece> ChessBoard::movePiece(ChessMove move) {
         grid[move.getEndX()][move.getEndY()] =
             std::move(grid[move.getStartX()][move.getStartY()]);
         grid[move.getStartX()][move.getStartY()] = nullptr;
-        // Update position cache for the piece that just moved
-        if (grid[move.getEndX()][move.getEndY()]) {
-            grid[move.getEndX()][move.getEndY()]->posX = move.getEndX();
-            grid[move.getEndX()][move.getEndY()]->posY = move.getEndY();
-        }
+        // Update position cache for the piece that just moved.
+        // The piece is always non-null here: the outer guard confirmed
+        // the source was non-null, and it is what we just moved to dest.
+        assert(grid[move.getEndX()][move.getEndY()] != nullptr);
+        grid[move.getEndX()][move.getEndY()]->posX = move.getEndX();
+        grid[move.getEndX()][move.getEndY()]->posY = move.getEndY();
         return displaced;
     } else
         return nullptr;

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -131,24 +131,8 @@ int ChessPiece::getIndex() const { return index; }
 bool ChessPiece::getWhite() const { return isWhite; }
 bool ChessPiece::getKingSide() const { return isKingSide; }
 
-int ChessPiece::getPosX() const  // O(64) scan; position is not stored on the piece
-{
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 8; j++) {
-            if (board->getPiece(i, j) == this) return i;
-        }
-    }
-    return -1;
-}
-
-int ChessPiece::getPosY() const {
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 8; j++) {
-            if (board->getPiece(i, j) == this) return j;
-        }
-    }
-    return -1;
-}
+int ChessPiece::getPosX() const { return posX; }  // O(1); cached by ChessBoard
+int ChessPiece::getPosY() const { return posY; }
 
 const char* ChessPiece::getID() const { return id; }
 
@@ -157,15 +141,15 @@ bool ChessPiece::move(int x, int y) {
         board !=
             nullptr)  // not sure what happens when *(nullptr) used as reference; can't be good.
     {
-        delete getMutablePiece(*board, x, y);  // check pointers !
-        movePiece(*board,
-                  ChessMove(getPosX(), getPosY(), x, y));  // and this will overwrite the pointer
+        // movePiece returns the displaced piece (if any) as a unique_ptr;
+        // it is automatically deleted when the return value is dropped.
+        (void)movePiece(*board, ChessMove(getPosX(), getPosY(), x, y));
         return true;
     } else
         return false;
 }
 
-ChessPiece* ChessPiece::movePiece(ChessBoard& cb, ChessMove move) const {
+std::unique_ptr<ChessPiece> ChessPiece::movePiece(ChessBoard& cb, ChessMove move) const {
     return cb.movePiece(move);
 }
 
@@ -173,14 +157,9 @@ ChessPiece* ChessPiece::getMutablePiece(ChessBoard& cb, int x, int y) const {
     return cb.getMoveablePiece(x, y);
 }
 
-ChessPiece* ChessPiece::setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const {
-    if (x < 0 || x > 7 || y < 0 || y > 7)
-        return nullptr;
-    else {
-        ChessPiece* temp = cb.grid[x][y];
-        cb.grid[x][y] = piece;
-        return temp;  // function caller's responsibility to prevent memory holes.
-    }
+void ChessPiece::setPiece(ChessBoard& cb, int x, int y, std::unique_ptr<ChessPiece> piece) const {
+    if (x < 0 || x > 7 || y < 0 || y > 7) return;
+    cb.place(x, y, std::move(piece));
 }
 
 int ChessPiece::getRootValue() {
@@ -280,10 +259,10 @@ bool Pawn::canMove(int x, int y, bool chkchk) const {
         // FIXME: en passant temp-undo doesn't remove the captured pawn, so
         // check detection is wrong for a horizontally-pinned en passant capture.
         // Tracked for a later PR.
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -327,12 +306,9 @@ bool Pawn::move(int x, int y) {
         hasMoved = true;
 
         if (isWhite == true && x == ox + 1 && abs(y - oy) == 1 && destEmpty) {
-            ChessPiece* capturedPawn = getMutablePiece(*board, ox, y);
-            delete capturedPawn;
+            // En passant: remove the captured pawn. unique_ptr in setPiece handles deletion.
             setPiece(*board, ox, y, nullptr);
         } else if (isWhite == false && x == ox - 1 && abs(y - oy) == 1 && destEmpty) {
-            ChessPiece* capturedPawn = getMutablePiece(*board, ox, y);
-            delete capturedPawn;
             setPiece(*board, ox, y, nullptr);
         }
 
@@ -396,10 +372,10 @@ bool Rook::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -468,10 +444,10 @@ bool Knight::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -542,10 +518,10 @@ bool Bishop::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -625,19 +601,19 @@ bool King::canMove(int x, int y, bool chkchk) const {
                     if (!piece->getMoved()) {
                         // Step the king through each intermediate square and verify
                         // it is not in check at any point (castling through check is illegal).
-                        movePiece(*board, ChessMove(cx, 4, cx, 4 + sign));
+                        (void)movePiece(*board, ChessMove(cx, 4, cx, 4 + sign));
                         if (chkchk && inCheck()) {
-                            movePiece(*board, ChessMove(cx, 4 + sign, cx, 4));
+                            (void)movePiece(*board, ChessMove(cx, 4 + sign, cx, 4));
                             return false;
                         }
 
-                        movePiece(*board, ChessMove(cx, 4 + sign, cx, 4 + sign * 2));
+                        (void)movePiece(*board, ChessMove(cx, 4 + sign, cx, 4 + sign * 2));
                         if (chkchk && inCheck()) {
-                            movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
+                            (void)movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
                             return false;
                         }
 
-                        movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
+                        (void)movePiece(*board, ChessMove(cx, 4 + sign * 2, cx, 4));
                     } else
                         return false;
                 } else
@@ -653,10 +629,10 @@ bool King::canMove(int x, int y, bool chkchk) const {
         // board scan. checkCheck() would search the board for this king and then
         // call inCheck() — but since we are already executing as the king, we
         // can call inCheck() directly. Both are equivalent; inCheck() is faster.
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(inCheck());
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -682,13 +658,13 @@ bool King::move(int x, int y) {
     if (b) {
         hasMoved = true;
         if (y == 6 && oy == 4) {
-            movePiece(*board, ChessMove(ox, 7, ox, 5));
+            (void)movePiece(*board, ChessMove(ox, 7, ox, 5));
             Rook* piece = dynamic_cast<Rook*>(getMutablePiece(*board, ox, 5));
             assert(piece);
             piece->markMoved();
         }
         if (y == 2 && oy == 4) {
-            movePiece(*board, ChessMove(ox, 0, ox, 3));
+            (void)movePiece(*board, ChessMove(ox, 0, ox, 3));
             Rook* piece = dynamic_cast<Rook*>(getMutablePiece(*board, ox, 3));
             assert(piece);
             piece->markMoved();
@@ -796,10 +772,10 @@ bool Queen::canMove(int x, int y, bool chkchk) const {
 
     if (chkchk) {
         // Temporarily execute and undo the move to test for self-check (see Pawn::canMove).
-        ChessPiece* temp = movePiece(*board, ChessMove(cx, cy, x, y));
+        auto temp = movePiece(*board, ChessMove(cx, cy, x, y));
         bool ret = !(board->checkCheck(isWhite));
-        movePiece(*board, ChessMove(x, y, cx, cy));
-        setPiece(*board, x, y, temp);
+        (void)movePiece(*board, ChessMove(x, y, cx, cy));
+        setPiece(*board, x, y, std::move(temp));
         return ret;
     } else
         return true;
@@ -838,63 +814,45 @@ PieceType Queen::getType() const { return QUEEN; }
 // CHESSBOARD
 
 ChessBoard::ChessBoard() {
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 8; j++) {
-            grid[i][j] = nullptr;
-        }
-    }
+    // Set up the pieces using place() which initialises posX/posY on each piece.
+    place(0, 0, std::make_unique<Rook>(WHITE, false, this, 0));
+    place(0, 1, std::make_unique<Knight>(WHITE, false, this, 0));
+    place(0, 2, std::make_unique<Bishop>(WHITE, false, this, 0));
+    place(0, 3, std::make_unique<Queen>(WHITE, this, 0));
+    place(0, 4, std::make_unique<King>(WHITE, this));
+    place(0, 5, std::make_unique<Bishop>(WHITE, true, this, 0));
+    place(0, 6, std::make_unique<Knight>(WHITE, true, this, 0));
+    place(0, 7, std::make_unique<Rook>(WHITE, true, this, 0));
 
-    // Set up the pieces
+    place(1, 0, std::make_unique<Pawn>(WHITE, false, this, 4));
+    place(1, 1, std::make_unique<Pawn>(WHITE, false, this, 3));
+    place(1, 2, std::make_unique<Pawn>(WHITE, false, this, 2));
+    place(1, 3, std::make_unique<Pawn>(WHITE, false, this, 1));
+    place(1, 4, std::make_unique<Pawn>(WHITE, true, this, 1));
+    place(1, 5, std::make_unique<Pawn>(WHITE, true, this, 2));
+    place(1, 6, std::make_unique<Pawn>(WHITE, true, this, 3));
+    place(1, 7, std::make_unique<Pawn>(WHITE, true, this, 4));
 
-    grid[0][0] = new Rook(WHITE, false, this, 0);
-    grid[0][1] = new Knight(WHITE, false, this, 0);
-    grid[0][2] = new Bishop(WHITE, false, this, 0);
-    grid[0][3] = new Queen(WHITE, this, 0);
-    grid[0][4] = new King(WHITE, this);
-    grid[0][5] = new Bishop(WHITE, true, this, 0);
-    grid[0][6] = new Knight(WHITE, true, this, 0);
-    grid[0][7] = new Rook(WHITE, true, this, 0);
+    place(6, 0, std::make_unique<Pawn>(BLACK, false, this, 4));
+    place(6, 1, std::make_unique<Pawn>(BLACK, false, this, 3));
+    place(6, 2, std::make_unique<Pawn>(BLACK, false, this, 2));
+    place(6, 3, std::make_unique<Pawn>(BLACK, false, this, 1));
+    place(6, 4, std::make_unique<Pawn>(BLACK, true, this, 1));
+    place(6, 5, std::make_unique<Pawn>(BLACK, true, this, 2));
+    place(6, 6, std::make_unique<Pawn>(BLACK, true, this, 3));
+    place(6, 7, std::make_unique<Pawn>(BLACK, true, this, 4));
 
-    grid[1][0] = new Pawn(WHITE, false, this, 4);
-    grid[1][1] = new Pawn(WHITE, false, this, 3);
-    grid[1][2] = new Pawn(WHITE, false, this, 2);
-    grid[1][3] = new Pawn(WHITE, false, this, 1);
-    grid[1][4] = new Pawn(WHITE, true, this, 1);
-    grid[1][5] = new Pawn(WHITE, true, this, 2);
-    grid[1][6] = new Pawn(WHITE, true, this, 3);
-    grid[1][7] = new Pawn(WHITE, true, this, 4);
-
-    grid[6][0] = new Pawn(BLACK, false, this, 4);
-    grid[6][1] = new Pawn(BLACK, false, this, 3);
-    grid[6][2] = new Pawn(BLACK, false, this, 2);
-    grid[6][3] = new Pawn(BLACK, false, this, 1);
-    grid[6][4] = new Pawn(BLACK, true, this, 1);
-    grid[6][5] = new Pawn(BLACK, true, this, 2);
-    grid[6][6] = new Pawn(BLACK, true, this, 3);
-    grid[6][7] = new Pawn(BLACK, true, this, 4);
-
-    grid[7][0] = new Rook(BLACK, false, this, 0);
-    grid[7][1] = new Knight(BLACK, false, this, 0);
-    grid[7][2] = new Bishop(BLACK, false, this, 0);
-    grid[7][3] = new Queen(BLACK, this, 0);
-    grid[7][4] = new King(BLACK, this);
-    grid[7][5] = new Bishop(BLACK, true, this, 0);
-    grid[7][6] = new Knight(BLACK, true, this, 0);
-    grid[7][7] = new Rook(BLACK, true, this, 0);
+    place(7, 0, std::make_unique<Rook>(BLACK, false, this, 0));
+    place(7, 1, std::make_unique<Knight>(BLACK, false, this, 0));
+    place(7, 2, std::make_unique<Bishop>(BLACK, false, this, 0));
+    place(7, 3, std::make_unique<Queen>(BLACK, this, 0));
+    place(7, 4, std::make_unique<King>(BLACK, this));
+    place(7, 5, std::make_unique<Bishop>(BLACK, true, this, 0));
+    place(7, 6, std::make_unique<Knight>(BLACK, true, this, 0));
+    place(7, 7, std::make_unique<Rook>(BLACK, true, this, 0));
 }
 
-ChessBoard::~ChessBoard()  // do not keep pointers to pieces in this grid after the board is
-                           // destroyed
-{
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 8; j++) {
-            if (grid[i][j] != nullptr) {
-                delete grid[i][j];
-                grid[i][j] = nullptr;
-            }
-        }
-    }
-}
+ChessBoard::~ChessBoard() {}  // unique_ptrs in grid[] clean up automatically
 
 const char* ChessBoard::toString() {
     // Layout: 8 ranks x 4 display rows/rank + 1 border row = 33 rows.
@@ -989,25 +947,38 @@ const char* ChessBoard::toString() {
 
 ChessPiece* ChessBoard::getMoveablePiece(int x, int y) {
     if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
-        return grid[x][y];
+        return grid[x][y].get();
     else
         return nullptr;
 }
 
-ChessPiece* ChessBoard::movePiece(ChessMove move) {
+void ChessBoard::place(int x, int y, std::unique_ptr<ChessPiece> p) {
+    if (p) {
+        p->posX = x;
+        p->posY = y;
+    }
+    grid[x][y] = std::move(p);
+}
+
+std::unique_ptr<ChessPiece> ChessBoard::movePiece(ChessMove move) {
     if (!move.isEnd() && grid[move.getStartX()][move.getStartY()] != nullptr) {
-        ChessPiece* temp = grid[move.getEndX()][move.getEndY()];
+        auto displaced = std::move(grid[move.getEndX()][move.getEndY()]);
         grid[move.getEndX()][move.getEndY()] =
-            grid[move.getStartX()][move.getStartY()];        // replaces destination
-        grid[move.getStartX()][move.getStartY()] = nullptr;  // leaves behind nothing
-        return temp;
+            std::move(grid[move.getStartX()][move.getStartY()]);
+        grid[move.getStartX()][move.getStartY()] = nullptr;
+        // Update position cache for the piece that just moved
+        if (grid[move.getEndX()][move.getEndY()]) {
+            grid[move.getEndX()][move.getEndY()]->posX = move.getEndX();
+            grid[move.getEndX()][move.getEndY()]->posY = move.getEndY();
+        }
+        return displaced;
     } else
         return nullptr;
 }
 
 const ChessPiece* ChessBoard::getPiece(int x, int y) const {
     if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
-        return grid[x][y];
+        return grid[x][y].get();
     else
         return nullptr;
 }
@@ -1071,18 +1042,18 @@ std::vector<ChessMove> ChessGame::getMoves(bool white) const {
     return all;
 }
 
-ChessPiece* ChessGame::makePiece(PieceType type, bool white, int y) {
+std::unique_ptr<ChessPiece> ChessGame::makePiece(PieceType type, bool white, int y) {
     bool ks = (y > 3);
     int idx = white ? whiteProms : blackProms;
     switch (type) {
         case QUEEN:
-            return new Queen(white, &board, idx, ks);
+            return std::make_unique<Queen>(white, &board, idx, ks);
         case ROOK:
-            return new Rook(white, ks, &board, idx);
+            return std::make_unique<Rook>(white, ks, &board, idx);
         case KNIGHT:
-            return new Knight(white, ks, &board, idx);
+            return std::make_unique<Knight>(white, ks, &board, idx);
         case BISHOP:
-            return new Bishop(white, ks, &board, idx);
+            return std::make_unique<Bishop>(white, ks, &board, idx);
         default:
             fprintf(stderr, "makePiece: invalid promotion type %d\n", static_cast<int>(type));
             std::abort();
@@ -1103,8 +1074,7 @@ bool ChessGame::makeMove(const ChessMove& cm) {
             // rather than routing through setPiece() to avoid the rulesOn guard.
             if (cm.getPromotion() != PAWN) {
                 int endX = cm.getEndX(), endY = cm.getEndY();
-                delete board.grid[endX][endY];
-                board.grid[endX][endY] = makePiece(cm.getPromotion(), movedColor, endY);
+                board.place(endX, endY, makePiece(cm.getPromotion(), movedColor, endY));
                 if (movedColor) whiteProms++;
                 else blackProms++;
             }
@@ -1128,8 +1098,7 @@ bool ChessGame::makeMove(const ChessMove& cm) {
         }
         return b;
     } else {
-        ChessPiece* displaced = board.movePiece(cm);
-        delete displaced;
+        (void)board.movePiece(cm);  // displaced piece auto-deleted by unique_ptr
         return true;
     }
 }
@@ -1138,13 +1107,10 @@ const char* ChessGame::getBoard() { return board.toString(); }
 
 const ChessPiece* ChessGame::getPiece(int x, int y) const { return board.getPiece(x, y); }
 
-void ChessGame::setPiece(int x, int y, ChessPiece* piece) {
+void ChessGame::setPiece(int x, int y, std::unique_ptr<ChessPiece> piece) {
     if (rulesOn) return;
-
     if (x < 0 || x > 7 || y < 0 || y > 7) return;
-
-    delete board.grid[x][y];
-    board.grid[x][y] = piece;
+    board.place(x, y, std::move(piece));
 }
 
 ChessBoard* ChessGame::getPieceBoard() { return &board; }

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -48,8 +49,9 @@ enum PieceType { PAWN, ROOK, KNIGHT, BISHOP, KING, QUEEN };
 /**
  * Abstract base class for all chess pieces.
  *
- * Pieces do not cache their board position; getPosX/getPosY scan the
- * full 8x8 grid on every call (O(64)).
+ * Each piece caches its board position in posX/posY; getPosX/getPosY
+ * return these in O(1). The cache is kept up to date by ChessBoard::movePiece
+ * and ChessBoard::place.
  *
  * Piece ID string (id): [color W/B][type P/R/N/B/K/Q][side K/Q][index digit]
  */
@@ -61,7 +63,7 @@ class ChessPiece  // ADT
     bool getWhite() const;
     bool getKingSide() const;
     int getIndex() const;
-    // Position is not cached; each call scans the full 8x8 board (O(64)).
+    // Position is cached in posX/posY; O(1).
     int getPosX() const;
     int getPosY() const;
     const char* getID() const;
@@ -112,13 +114,15 @@ class ChessPiece  // ADT
     char id[4 + 1];
     ChessBoard* board;
     const int index;
+    int posX = -1;  // cached position; updated by ChessBoard::movePiece and place
+    int posY = -1;
 
     // Virtual functions cannot be friended directly. These non-virtual
     // forwarding methods give piece subclasses access to ChessBoard's private
     // movePiece, getMoveablePiece, and setPiece methods.
-    ChessPiece* movePiece(ChessBoard& cb, ChessMove move) const;
+    std::unique_ptr<ChessPiece> movePiece(ChessBoard& cb, ChessMove move) const;
     ChessPiece* getMutablePiece(ChessBoard& cb, int x, int y) const;
-    ChessPiece* setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
+    void setPiece(ChessBoard& cb, int x, int y, std::unique_ptr<ChessPiece> piece) const;
 };
 
 class Pawn : public ChessPiece {
@@ -223,14 +227,16 @@ class ChessBoard {
     friend class ChessGame;
 
    private:
-    ChessPiece* grid[8][8];
-    ChessPiece* movePiece(ChessMove move);
+    std::unique_ptr<ChessPiece> grid[8][8];
+    std::unique_ptr<ChessPiece> movePiece(ChessMove move);
     ChessPiece* getMoveablePiece(int x, int y);
-    friend ChessPiece* ChessPiece::movePiece(ChessBoard& cb, ChessMove move)
+    void place(int x, int y, std::unique_ptr<ChessPiece> p);
+    friend std::unique_ptr<ChessPiece> ChessPiece::movePiece(ChessBoard& cb, ChessMove move)
         const;  // virtual functions cannot be friends; these functions
     friend ChessPiece* ChessPiece::getMutablePiece(
         ChessBoard& cb, int x, int y) const;  // should allow ChessPiece to get what it needs
-    friend ChessPiece* ChessPiece::setPiece(ChessBoard& cb, int x, int y, ChessPiece* piece) const;
+    friend void ChessPiece::setPiece(ChessBoard& cb, int x, int y,
+                                     std::unique_ptr<ChessPiece> piece) const;
 
     std::string repr;
 };
@@ -302,7 +308,7 @@ class ChessGame {
 
     const char* getBoard();
     const ChessPiece* getPiece(int x, int y) const;
-    void setPiece(int x, int y, ChessPiece* piece);
+    void setPiece(int x, int y, std::unique_ptr<ChessPiece> piece);
 
     bool getTurn() const;
 
@@ -314,7 +320,7 @@ class ChessGame {
     ChessBoard board;
     int whiteProms = 0;
     int blackProms = 0;
-    ChessPiece* makePiece(PieceType type, bool white, int y);
+    std::unique_ptr<ChessPiece> makePiece(PieceType type, bool white, int y);
 };
 
 #endif  // def _CHESS_H

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -3,6 +3,7 @@
 // Coverage: make coverage
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <string>
 
 #include "chess.h"
@@ -24,10 +25,12 @@ struct CustomBoard {
     CustomBoard() : b(game.getPieceBoard()) {
         game.setRules(false);
         for (int x = 0; x < 8; x++)
-            for (int y = 0; y < 8; y++) game.setPiece(x, y, NULL);
+            for (int y = 0; y < 8; y++) game.setPiece(x, y, nullptr);
     }
 
-    void place(int x, int y, ChessPiece* piece) { game.setPiece(x, y, piece); }
+    void place(int x, int y, ChessPiece* piece) {
+        game.setPiece(x, y, std::unique_ptr<ChessPiece>(piece));
+    }
 
     // Call after placing all pieces to enable normal rules.
     void activate() { game.setRules(true); }


### PR DESCRIPTION
## Summary

- `ChessBoard::grid[8][8]` changes from raw `ChessPiece*` to `std::unique_ptr<ChessPiece>` — eliminates all manual `delete`/`delete[]` calls for pieces; destructor becomes trivial.
- New `ChessBoard::place(x, y, unique_ptr<ChessPiece>)` private helper centralises ownership transfer and position cache updates.
- `ChessBoard::movePiece()` returns `unique_ptr<ChessPiece>` (the displaced piece); callers use `auto temp = ...` / `(void)...` / `std::move(temp)` as appropriate.
- `ChessPiece` gains `int posX = -1, posY = -1` position cache fields; `getPosX()/getPosY()` drop the O(64) board scan, becoming O(1). Cache is kept current by `movePiece()` and `place()`.
- All `canMove()` temp-undo patterns updated to use `auto temp = movePiece(...)` + `std::move(temp)` restore.
- `ChessGame::setPiece()` and `makePiece()` take/return `unique_ptr<ChessPiece>`.
- Tests: `CustomBoard` updated to use `nullptr` and wrap raw pointers in `unique_ptr`.

**Note:** This PR targets `master` (GitHub stacked PR limitation — the base branch must exist in the upstream repo). Until PR #11 (6b) is merged, the diff includes 6b changes; afterward the diff will show only 6c changes.

## Test plan

- [x] `cmake --build chess/build -j4 --clean-first` — clean build, no errors (only pre-existing argc/argv warnings in main)
- [x] `./chess/build/chess_tests` — all 68 tests pass (3 tests for `length`/`sort`/`copy+concat` removed in 6b; 5 promotion tests added in 6b; net 68)
- [ ] Review: position cache correctly maintained through moves and undos in `canMove()`
- [ ] Review: `ChessBoard` destructor is now trivial (no manual cleanup loop)
- [ ] Review: no raw `new`/`delete` for pieces remain in `chess.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)