### PR TITLE
chess: add move history (baseline step 6e)

### DIFF
--- a/chess/ROADMAP.md
+++ b/chess/ROADMAP.md
@@ -86,29 +86,28 @@ Problems in the existing code that will be addressed during modernization:
 
 ### Phase 6: Architectural Improvements
 
-#### ChessMove redesign
-- `ChessMove` currently packs four 3-bit fields into a `short int`; replace with a plain
-  `struct { int8_t startX, startY, endX, endY; }` or similar — cleaner and easier to extend.
-- Add a pawn promotion field to `ChessMove` so the promoted piece type travels with the move.
-  Consider two approaches:
-  1. **In-move**: `ChessMove` gains an optional `PieceType promotion` field; callers that need
-     promotion set it, others leave it at a sentinel (e.g. `PAWN` = no promotion).
-  2. **UI-layer detection**: Keep `ChessMove` simple; `ChessGame` (or `Main.cpp`) detects
-     when a pawn reaches the back rank after `makeMove()` and prompts for piece selection.
-  Approach 2 is simpler now but defers the problem; approach 1 enables a cleaner API for Phase 7.
-- After ChessMove changes, walk through the codebase for potential undefined behaviour (UB):
-  signed overflow in the old bit-packing arithmetic, out-of-bounds array access, invalid casts,
-  etc. Document findings and fix any real issues.
+#### ChessMove redesign *(done — PR #10, merged 2026-02-20)*
+- [x] `ChessMove` plain `int8_t` fields replacing packed `short int`
+- [x] Promotion field (`PieceType`) on `ChessMove` (approach 1: in-move)
+- [x] UB audit after ChessMove changes (assert on King::move() castling dynamic_cast)
 
-#### Other improvements
-- Replace raw owning pointers with `std::unique_ptr<ChessPiece>`
-- Store piece position on the piece (avoid O(64) scan); keep board as secondary index
-- Replace raw move arrays with `std::vector<ChessMove>`
-- Encapsulate pawn promotion within `ChessGame` (remove from `Main.cpp`)
-- Complete algebraic notation parsing
-- Add move history (`std::vector<ChessMove>` in `ChessGame`)
-- Evaluate bitboard representation for move generation (research spike)
-- Add 50-move rule and threefold repetition draw detection
+#### Vector moves + promotion encapsulation *(done — PR #11, merged 2026-03-11)*
+- [x] Replace raw move arrays with `std::vector<ChessMove>`
+- [x] Encapsulate pawn promotion within `ChessGame` (remove from `Main.cpp`)
+
+#### unique_ptr + position caching *(done — PR #12, merged 2026-03-11)*
+- [x] Replace raw owning pointers with `std::unique_ptr<ChessPiece>`
+- [x] Store piece position on the piece (avoid O(64) scan); keep board as secondary index
+
+#### Raw pointer cleanup *(done — PR #13, merged 2026-03-11)*
+- [x] Replace `ChessBoard*` back-references with `ChessBoard&` references
+
+#### Remaining improvements (in order)
+1. Add move history (`std::vector<ChessMove>` in `ChessGame`) — PR 6e
+2. FEN serialization/deserialization (pull forward from Phase 7) — enables threefold repetition
+3. 50-move rule and threefold repetition draw detection — uses move history + FEN
+4. Complete algebraic notation parsing — CLI improvement, independent
+5. Evaluate bitboard representation for move generation (research spike, optional)
 
 ### Phase 7: LLM Tool API
 - FEN serialization and deserialization

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1079,12 +1079,15 @@ std::unique_ptr<ChessPiece> ChessGame::makePiece(PieceType type, bool white, int
 
 bool ChessGame::getTurn() const { return whiteTurn; }
 
+const std::vector<ChessMove>& ChessGame::getHistory() const { return history; }
+
 bool ChessGame::makeMove(const ChessMove& cm) {
     if (rulesOn) {
         ChessPiece* piece = board.getMoveablePiece(cm.getStartX(), cm.getStartY());
         if (piece == nullptr || piece->getWhite() != whiteTurn) return false;
         bool b = piece->move(cm.getEndX(), cm.getEndY());
         if (b) {
+            history.push_back(cm);
             bool movedColor = whiteTurn;  // capture before flip
             // Handle pawn promotion: replace pawn with requested piece type.
             // Write directly to board.grid (ChessGame is a friend of ChessBoard)

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -290,6 +290,10 @@ class ChessMove {
  * Pawn promotion is handled inside this class via makeMove(): when a
  * ChessMove carries a non-PAWN promotion field, the pawn is automatically
  * replaced with the requested piece type.
+ *
+ * Move history: every successful rules-on move is recorded in order.
+ * Retrieve via getHistory(). Rules-off moves (used during board setup)
+ * are not recorded.
  */
 class ChessGame {
    public:
@@ -312,6 +316,8 @@ class ChessGame {
 
     bool getTurn() const;
 
+    const std::vector<ChessMove>& getHistory() const;
+
     ChessBoard& getPieceBoard();
 
    private:
@@ -320,6 +326,7 @@ class ChessGame {
     ChessBoard board;
     int whiteProms = 0;
     int blackProms = 0;
+    std::vector<ChessMove> history;
     std::unique_ptr<ChessPiece> makePiece(PieceType type, bool white, int y);
 };
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -829,3 +829,67 @@ TEST_CASE("ChessMove: getPromotion returns promotion type for promotion move", "
     REQUIRE(cm.getPromotion() == QUEEN);
     REQUIRE(!cm.isEnd());
 }
+
+// ============================================================================
+// Move History
+// ============================================================================
+
+TEST_CASE("ChessGame: history is empty at start", "[ChessGame][History]") {
+    ChessGame game;
+    REQUIRE(game.getHistory().empty());
+}
+
+TEST_CASE("ChessGame: history records a move after makeMove", "[ChessGame][History]") {
+    ChessGame game;
+    ChessMove e2e4(1, 4, 3, 4);  // e2-e4
+    REQUIRE(game.makeMove(e2e4));
+    REQUIRE(game.getHistory().size() == 1);
+    const ChessMove& recorded = game.getHistory()[0];
+    REQUIRE(recorded.getStartX() == 1);
+    REQUIRE(recorded.getStartY() == 4);
+    REQUIRE(recorded.getEndX() == 3);
+    REQUIRE(recorded.getEndY() == 4);
+}
+
+TEST_CASE("ChessGame: history records multiple moves in order", "[ChessGame][History]") {
+    ChessGame game;
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // e2-e4
+    REQUIRE(game.makeMove(ChessMove(6, 4, 4, 4)));  // e7-e5
+    REQUIRE(game.makeMove(ChessMove(0, 5, 3, 2)));  // Bf1-c4
+    REQUIRE(game.getHistory().size() == 3);
+    // First move is e2-e4
+    REQUIRE(game.getHistory()[0].getStartX() == 1);
+    REQUIRE(game.getHistory()[0].getEndX() == 3);
+    // Second move is e7-e5
+    REQUIRE(game.getHistory()[1].getStartX() == 6);
+    REQUIRE(game.getHistory()[1].getEndX() == 4);
+    // Third move is Bf1-c4
+    REQUIRE(game.getHistory()[2].getStartX() == 0);
+    REQUIRE(game.getHistory()[2].getStartY() == 5);
+}
+
+TEST_CASE("ChessGame: failed move is not recorded in history", "[ChessGame][History]") {
+    ChessGame game;
+    // Try to move black piece on white's turn — should fail
+    REQUIRE_FALSE(game.makeMove(ChessMove(6, 4, 4, 4)));
+    REQUIRE(game.getHistory().empty());
+}
+
+TEST_CASE("ChessGame: history records promotion moves with promotion type",
+          "[ChessGame][History]") {
+    CustomBoard cb;
+    cb.place(6, 3, new Pawn(WHITE, false, cb.b, 1));  // white pawn at d7
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    REQUIRE(cb.game.makeMove(ChessMove(6, 3, 7, 3, QUEEN)));
+    REQUIRE(cb.game.getHistory().size() == 1);
+    REQUIRE(cb.game.getHistory()[0].getPromotion() == QUEEN);
+}
+
+TEST_CASE("ChessGame: rules-off moves are not recorded in history", "[ChessGame][History]") {
+    ChessGame game;
+    game.setRules(false);
+    game.makeMove(ChessMove(1, 4, 3, 4));
+    REQUIRE(game.getHistory().empty());
+}


### PR DESCRIPTION
## Summary

- Adds `std::vector<ChessMove> history` to `ChessGame`, populated by `makeMove()` on each successful rules-on move
- New public API: `getHistory()` returns `const std::vector<ChessMove>&`
- Rules-off moves (board setup) are not recorded
- Updates ROADMAP.md Phase 6 with completion dates for PRs #10–#13 and planned order for remaining improvements

## Tests

6 new test cases (74 total, all passing):
- History empty at start
- Single move recorded with correct coordinates
- Multiple moves recorded in order
- Failed move not recorded
- Promotion type preserved in history
- Rules-off moves excluded

## Test plan

- [x] All 74 tests pass locally
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)