### PR TITLE
chess: add FEN serialization (baseline step 6f)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -704,6 +704,8 @@ bool King::inCheck() const {
     return false;
 }
 
+bool King::getMoved() const { return hasMoved; }
+
 PieceType King::getType() const { return KING; }
 
 ///////
@@ -1085,9 +1087,17 @@ bool ChessGame::makeMove(const ChessMove& cm) {
     if (rulesOn) {
         ChessPiece* piece = board.getMoveablePiece(cm.getStartX(), cm.getStartY());
         if (piece == nullptr || piece->getWhite() != whiteTurn) return false;
+        bool isPawnMove = (piece->getType() == PAWN);
+        bool isCapture = (board.getPiece(cm.getEndX(), cm.getEndY()) != nullptr);
+        // En passant is also a capture (destination is empty but a pawn is taken).
+        if (isPawnMove && !isCapture && cm.getStartY() != cm.getEndY()) isCapture = true;
         bool b = piece->move(cm.getEndX(), cm.getEndY());
         if (b) {
             history.push_back(cm);
+            if (isPawnMove || isCapture)
+                halfmoveClock = 0;
+            else
+                halfmoveClock++;
             bool movedColor = whiteTurn;  // capture before flip
             // Handle pawn promotion: replace pawn with requested piece type.
             // Write directly to board.grid (ChessGame is a friend of ChessBoard)
@@ -1131,6 +1141,114 @@ void ChessGame::setPiece(int x, int y, std::unique_ptr<ChessPiece> piece) {
     if (rulesOn) return;
     if (x < 0 || x > 7 || y < 0 || y > 7) return;
     board.place(x, y, std::move(piece));
+}
+
+std::string ChessGame::toFen() const {
+    std::string fen;
+
+    // 1. Piece placement (rank 8 down to rank 1 = x=7 down to x=0)
+    for (int x = 7; x >= 0; x--) {
+        int empty = 0;
+        for (int y = 0; y < 8; y++) {
+            const ChessPiece* p = board.getPiece(x, y);
+            if (p == nullptr) {
+                empty++;
+            } else {
+                if (empty > 0) {
+                    fen += std::to_string(empty);
+                    empty = 0;
+                }
+                char c;
+                switch (p->getType()) {
+                    case PAWN: c = 'p'; break;
+                    case ROOK: c = 'r'; break;
+                    case KNIGHT: c = 'n'; break;
+                    case BISHOP: c = 'b'; break;
+                    case QUEEN: c = 'q'; break;
+                    case KING: c = 'k'; break;
+                }
+                if (p->getWhite()) c = c - 32;  // uppercase for white
+                fen += c;
+            }
+        }
+        if (empty > 0) fen += std::to_string(empty);
+        if (x > 0) fen += '/';
+    }
+
+    // 2. Active color
+    fen += whiteTurn ? " w" : " b";
+
+    // 3. Castling availability
+    std::string castling;
+    // White kingside: king at (0,4) unmoved, rook at (0,7) unmoved
+    const ChessPiece* wk = board.getPiece(0, 4);
+    if (wk != nullptr && wk->getType() == KING && wk->getWhite()) {
+        const King* king = dynamic_cast<const King*>(wk);
+        if (!king->getMoved()) {
+            const ChessPiece* wr = board.getPiece(0, 7);
+            if (wr != nullptr && wr->getType() == ROOK && wr->getWhite()) {
+                const Rook* rook = dynamic_cast<const Rook*>(wr);
+                if (!rook->getMoved()) castling += 'K';
+            }
+            const ChessPiece* wqr = board.getPiece(0, 0);
+            if (wqr != nullptr && wqr->getType() == ROOK && wqr->getWhite()) {
+                const Rook* rook = dynamic_cast<const Rook*>(wqr);
+                if (!rook->getMoved()) castling += 'Q';
+            }
+        }
+    }
+    // Black kingside: king at (7,4) unmoved, rook at (7,7) unmoved
+    const ChessPiece* bk = board.getPiece(7, 4);
+    if (bk != nullptr && bk->getType() == KING && !bk->getWhite()) {
+        const King* king = dynamic_cast<const King*>(bk);
+        if (!king->getMoved()) {
+            const ChessPiece* br = board.getPiece(7, 7);
+            if (br != nullptr && br->getType() == ROOK && !br->getWhite()) {
+                const Rook* rook = dynamic_cast<const Rook*>(br);
+                if (!rook->getMoved()) castling += 'k';
+            }
+            const ChessPiece* bqr = board.getPiece(7, 0);
+            if (bqr != nullptr && bqr->getType() == ROOK && !bqr->getWhite()) {
+                const Rook* rook = dynamic_cast<const Rook*>(bqr);
+                if (!rook->getMoved()) castling += 'q';
+            }
+        }
+    }
+    fen += ' ';
+    fen += castling.empty() ? "-" : castling;
+
+    // 4. En passant target square
+    std::string ep = "-";
+    for (int y = 0; y < 8; y++) {
+        // En passant target is on the square "behind" the pawn that just double-advanced.
+        // Check pawns that have the enPassant flag set.
+        // White pawn with enPassant is at row 3 (just moved from row 1 to 3); target = row 2.
+        // Black pawn with enPassant is at row 4 (just moved from row 6 to 4); target = row 5.
+        for (int x = 0; x < 8; x++) {
+            const ChessPiece* p = board.getPiece(x, y);
+            if (p != nullptr && p->getType() == PAWN) {
+                const Pawn* pawn = dynamic_cast<const Pawn*>(p);
+                if (pawn->getEnPassant()) {
+                    int targetX = pawn->getWhite() ? (x - 1) : (x + 1);
+                    ep = "";
+                    ep += ChessMove::fileLetters[y];
+                    ep += std::to_string(targetX + 1);
+                }
+            }
+        }
+    }
+    fen += ' ';
+    fen += ep;
+
+    // 5. Halfmove clock
+    fen += ' ';
+    fen += std::to_string(halfmoveClock);
+
+    // 6. Fullmove number
+    fen += ' ';
+    fen += std::to_string(1 + (int)history.size() / 2);
+
+    return fen;
 }
 
 ChessBoard& ChessGame::getPieceBoard() { return board; }

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -318,6 +318,8 @@ class ChessGame {
 
     const std::vector<ChessMove>& getHistory() const;
 
+    std::string toFen() const;
+
     ChessBoard& getPieceBoard();
 
    private:
@@ -326,6 +328,7 @@ class ChessGame {
     ChessBoard board;
     int whiteProms = 0;
     int blackProms = 0;
+    int halfmoveClock = 0;
     std::vector<ChessMove> history;
     std::unique_ptr<ChessPiece> makePiece(PieceType type, bool white, int y);
 };

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -893,3 +893,150 @@ TEST_CASE("ChessGame: rules-off moves are not recorded in history", "[ChessGame]
     game.makeMove(ChessMove(1, 4, 3, 4));
     REQUIRE(game.getHistory().empty());
 }
+
+// ============================================================================
+// FEN Serialization
+// ============================================================================
+
+TEST_CASE("ChessGame: initial position FEN", "[ChessGame][FEN]") {
+    ChessGame game;
+    REQUIRE(game.toFen() ==
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+}
+
+TEST_CASE("ChessGame: FEN after 1. e4", "[ChessGame][FEN]") {
+    ChessGame game;
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // e2-e4
+    REQUIRE(game.toFen() ==
+            "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+}
+
+TEST_CASE("ChessGame: FEN after 1. e4 e5", "[ChessGame][FEN]") {
+    ChessGame game;
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // e2-e4
+    REQUIRE(game.makeMove(ChessMove(6, 4, 4, 4)));  // e7-e5
+    REQUIRE(game.toFen() ==
+            "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2");
+}
+
+TEST_CASE("ChessGame: FEN castling rights removed after king moves", "[ChessGame][FEN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));
+    cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.activate();
+    // Move white king
+    REQUIRE(cb.game.makeMove(ChessMove(0, 4, 0, 5)));
+    std::string fen = cb.game.toFen();
+    // After king moves, white has no castling rights; black has none either
+    // FEN castling field should be "-"
+    // Extract castling field (3rd space-separated field)
+    int spaces = 0;
+    std::string castling;
+    for (char c : fen) {
+        if (c == ' ') { spaces++; continue; }
+        if (spaces == 2) castling += c;
+        if (spaces > 2) break;
+    }
+    REQUIRE(castling == "-");
+}
+
+TEST_CASE("ChessGame: FEN castling rights after only kingside rook moves", "[ChessGame][FEN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));
+    cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.activate();
+    // Move kingside rook
+    REQUIRE(cb.game.makeMove(ChessMove(0, 7, 1, 7)));
+    std::string fen = cb.game.toFen();
+    // White should still have queenside castling (Q), but not kingside
+    int spaces = 0;
+    std::string castling;
+    for (char c : fen) {
+        if (c == ' ') { spaces++; continue; }
+        if (spaces == 2) castling += c;
+        if (spaces > 2) break;
+    }
+    REQUIRE(castling == "Q");
+}
+
+TEST_CASE("ChessGame: FEN with empty board except kings", "[ChessGame][FEN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.activate();
+    REQUIRE(cb.game.toFen() == "4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+}
+
+TEST_CASE("ChessGame: FEN halfmove clock resets on pawn move", "[ChessGame][FEN]") {
+    ChessGame game;
+    // 1. Nf3 Nf6  (two non-pawn, non-capture moves → halfmove clock = 2)
+    REQUIRE(game.makeMove(ChessMove(0, 6, 2, 5)));  // Ng1-f3
+    REQUIRE(game.makeMove(ChessMove(7, 6, 5, 5)));  // Ng8-f6
+    std::string fen = game.toFen();
+    // Extract halfmove clock (5th space-separated field)
+    int spaces = 0;
+    std::string halfmove;
+    for (char c : fen) {
+        if (c == ' ') { spaces++; continue; }
+        if (spaces == 4) halfmove += c;
+        if (spaces > 4) break;
+    }
+    REQUIRE(halfmove == "2");
+
+    // Now a pawn move resets halfmove clock to 0
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // e2-e4
+    fen = game.toFen();
+    spaces = 0;
+    halfmove.clear();
+    for (char c : fen) {
+        if (c == ' ') { spaces++; continue; }
+        if (spaces == 4) halfmove += c;
+        if (spaces > 4) break;
+    }
+    REQUIRE(halfmove == "0");
+}
+
+TEST_CASE("ChessGame: FEN halfmove clock resets on capture", "[ChessGame][FEN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(3, 3, new Knight(WHITE, false, cb.b));
+    // Knight from (3,3) can reach (4,1) — place black piece there for capture.
+    cb.place(4, 1, new Knight(BLACK, false, cb.b));
+    cb.activate();
+    // Non-capture king moves to build up the clock.
+    REQUIRE(cb.game.makeMove(ChessMove(0, 4, 0, 5)));  // halfmove = 1
+    REQUIRE(cb.game.makeMove(ChessMove(7, 4, 7, 5)));  // halfmove = 2
+    // White knight captures black knight at (4,1): halfmove resets to 0
+    REQUIRE(cb.game.makeMove(ChessMove(3, 3, 4, 1)));
+    std::string fen = cb.game.toFen();
+    int spaces = 0;
+    std::string halfmove;
+    for (char c : fen) {
+        if (c == ' ') { spaces++; continue; }
+        if (spaces == 4) halfmove += c;
+        if (spaces > 4) break;
+    }
+    REQUIRE(halfmove == "0");
+}
+
+TEST_CASE("ChessGame: FEN fullmove number increments after black moves", "[ChessGame][FEN]") {
+    ChessGame game;
+    // Initial: fullmove = 1
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // 1. e4
+    // After white's first move, still fullmove 1
+    std::string fen = game.toFen();
+    REQUIRE(fen.back() == '1');
+    REQUIRE(game.makeMove(ChessMove(6, 4, 4, 4)));  // 1... e5
+    // After black's first move, fullmove = 2
+    fen = game.toFen();
+    REQUIRE(fen.back() == '2');
+    REQUIRE(game.makeMove(ChessMove(0, 6, 2, 5)));  // 2. Nf3
+    REQUIRE(game.makeMove(ChessMove(7, 1, 5, 2)));  // 2... Nc6
+    fen = game.toFen();
+    REQUIRE(fen.back() == '3');
+}


### PR DESCRIPTION
## Summary

- Adds `ChessGame::toFen()` producing a standard FEN string with all six fields:
  piece placement, active color, castling availability, en passant target square,
  halfmove clock, and fullmove number
- Adds `halfmoveClock` tracking to `makeMove()`: resets on pawn moves and captures
  (including en passant), increments otherwise
- Implements `King::getMoved()` (was declared in header but never defined)

This is step 2 of the remaining Phase 6 improvements, pulled forward from Phase 7.
FEN serialization enables threefold repetition detection in the next step.

## Tests

9 new test cases (83 total, all passing):
- Initial position FEN matches standard starting FEN
- FEN after 1. e4 (with en passant target square `e3`)
- FEN after 1. e4 e5 (en passant target `e6`, fullmove 2)
- Castling rights removed after king moves
- Castling rights partial after kingside rook moves
- Empty board (kings only) FEN
- Halfmove clock resets on pawn move
- Halfmove clock resets on capture
- Fullmove number increments after black moves

## Test plan

- [x] All 83 tests pass locally
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)