### PR TITLE
chess: add SAN parsing (baseline step 6h)

### DIFF
--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -11,9 +11,6 @@
 
 void printMoves(bool color, const ChessGame& game);
 void printMoveList(const std::vector<ChessMove>& moves);
-// TODO: complete algebraic notation parsing (Phase 6)
-// ChessMove parseAlgMove( const char * szMove, const ChessBoard & board );
-// int stdMoves( const char * szMove, const ChessBoard & board );
 
 int main(int argc, char* argv[]) {
     srand(time(nullptr));  // initialize random number generator
@@ -22,9 +19,8 @@ int main(int argc, char* argv[]) {
     std::string input;
 
     printf("Chess Version 1.0\n\n");
-    printf(
-        "Commands:\nx#-x#\t\tmove\nend\t\texit\nmoves\t\tshow moves\nmoves x#\tshow moves at x#\n");
-    printf("rand\t\tmake a random move\n\n");
+    printf("Commands:\nNf3, e4, O-O\tSAN move\nx#-x#\t\tLAN move\nend\t\texit\n");
+    printf("moves\t\tshow moves\nmoves x#\tshow moves at x#\nrand\t\trandom move\n\n");
 
     while (true) {
         if (print) {
@@ -80,24 +76,28 @@ int main(int argc, char* argv[]) {
                 print = true;
             }
         } else {
-            ChessMove move = ChessMove(input.c_str());
-            // Temporary: if a pawn is moving to the back rank, ask for the
-            // promotion piece. Will be superseded by the algebraic notation
-            // parser in Phase 6.
-            const ChessPiece* piece = game.getPiece(move.getStartX(), move.getStartY());
-            if (piece != nullptr && piece->getType() == PAWN) {
-                int endRank = move.getEndX();
-                bool isPromoRank = (piece->getWhite() == WHITE) ? endRank == 7 : endRank == 0;
-                if (isPromoRank) {
-                    printf("Promote to? (q=queen, r=rook, b=bishop, n=knight): ");
-                    std::string promo;
-                    if (std::getline(std::cin, promo)) {
-                        PieceType pt = QUEEN;  // default to queen
-                        if (promo == "r") pt = ROOK;
-                        else if (promo == "b") pt = BISHOP;
-                        else if (promo == "n") pt = KNIGHT;
-                        move = ChessMove(move.getStartX(), move.getStartY(), endRank,
-                                         move.getEndY(), pt);
+            // Try SAN first (e.g., "e4", "Nf3", "O-O", "exd5", "e8=Q").
+            // Falls back to LAN (e.g., "e2-e4", "e2e4") if SAN doesn't match.
+            ChessMove move = game.parseSan(input);
+            if (move.isEnd()) {
+                // SAN didn't match — try LAN. For LAN promotion, prompt the user.
+                move = ChessMove(input.c_str());
+                const ChessPiece* piece = game.getPiece(move.getStartX(), move.getStartY());
+                if (piece != nullptr && piece->getType() == PAWN) {
+                    int endRank = move.getEndX();
+                    bool isPromoRank =
+                        (piece->getWhite() == WHITE) ? endRank == 7 : endRank == 0;
+                    if (isPromoRank) {
+                        printf("Promote to? (q=queen, r=rook, b=bishop, n=knight): ");
+                        std::string promo;
+                        if (std::getline(std::cin, promo)) {
+                            PieceType pt = QUEEN;
+                            if (promo == "r") pt = ROOK;
+                            else if (promo == "b") pt = BISHOP;
+                            else if (promo == "n") pt = KNIGHT;
+                            move = ChessMove(move.getStartX(), move.getStartY(), endRank,
+                                             move.getEndY(), pt);
+                        }
                     }
                 }
             }
@@ -120,13 +120,3 @@ void printMoveList(const std::vector<ChessMove>& moves) {
         printf("%s\n", m.toString());
     }
 }
-
-// TODO (Phase 6): implement full algebraic notation parsing.
-// The function below is incomplete and currently unused. Commented out to
-// suppress compiler warnings until the implementation is ready.
-//
-// ChessMove parseAlgMove( const char * szMove, const ChessGame & game )
-// {
-//     ... (incomplete stub — O-O/O-O-O castling partially handled,
-//          pawn moves and piece moves not implemented)
-// }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1251,4 +1251,123 @@ std::string ChessGame::toFen() const {
     return fen;
 }
 
+ChessMove ChessGame::parseSan(const std::string& san) const {
+    if (san.empty()) return ChessMove();
+
+    // Strip check/checkmate suffixes (+, #) for parsing.
+    std::string s = san;
+    while (!s.empty() && (s.back() == '+' || s.back() == '#')) s.pop_back();
+    if (s.empty()) return ChessMove();
+
+    // Castling.
+    if (s == "O-O" || s == "0-0") {
+        int rank = whiteTurn ? 0 : 7;
+        ChessMove cm(rank, 4, rank, 6);
+        // Verify it's legal.
+        auto moves = getMoves(whiteTurn);
+        for (const auto& m : moves) {
+            if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
+                m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
+                return m;
+        }
+        return ChessMove();
+    }
+    if (s == "O-O-O" || s == "0-0-0") {
+        int rank = whiteTurn ? 0 : 7;
+        ChessMove cm(rank, 4, rank, 2);
+        auto moves = getMoves(whiteTurn);
+        for (const auto& m : moves) {
+            if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
+                m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
+                return m;
+        }
+        return ChessMove();
+    }
+
+    // Parse promotion suffix (e.g., "=Q", "=N").
+    PieceType promo = PAWN;
+    {
+        size_t eq = s.find('=');
+        if (eq != std::string::npos && eq + 1 < s.size()) {
+            char pc = s[eq + 1];
+            switch (pc) {
+                case 'Q': case 'q': promo = QUEEN; break;
+                case 'R': case 'r': promo = ROOK; break;
+                case 'B': case 'b': promo = BISHOP; break;
+                case 'N': case 'n': promo = KNIGHT; break;
+                default: return ChessMove();
+            }
+            s = s.substr(0, eq);
+        }
+    }
+
+    // Determine piece type and strip the piece letter.
+    PieceType pieceType = PAWN;
+    if (!s.empty() && s[0] >= 'A' && s[0] <= 'Z') {
+        switch (s[0]) {
+            case 'K': pieceType = KING; break;
+            case 'Q': pieceType = QUEEN; break;
+            case 'R': pieceType = ROOK; break;
+            case 'B': pieceType = BISHOP; break;
+            case 'N': pieceType = KNIGHT; break;
+            default: return ChessMove();
+        }
+        s = s.substr(1);
+    }
+
+    // Remove 'x' capture indicator.
+    std::string cleaned;
+    for (char c : s) {
+        if (c != 'x') cleaned += c;
+    }
+    s = cleaned;
+
+    // Now s should be one of:
+    //   "e4"       — destination only (pawn or piece)
+    //   "fe4"      — file disambiguation + destination (pawn capture or piece)
+    //   "1e4"      — rank disambiguation + destination
+    //   "f1e4"     — full disambiguation (file+rank) + destination
+
+    if (s.size() < 2) return ChessMove();
+
+    // Destination is always the last two characters.
+    int endY = s[s.size() - 2] - 'a';
+    int endX = s[s.size() - 1] - '1';
+    if (endX < 0 || endX > 7 || endY < 0 || endY > 7) return ChessMove();
+
+    // Disambiguation from remaining characters.
+    int disambigFile = -1;  // 0-7 if specified
+    int disambigRank = -1;  // 0-7 if specified
+    std::string prefix = s.substr(0, s.size() - 2);
+    for (char c : prefix) {
+        if (c >= 'a' && c <= 'h') disambigFile = c - 'a';
+        else if (c >= '1' && c <= '8') disambigRank = c - '1';
+        else return ChessMove();
+    }
+
+    // Find matching legal move.
+    auto moves = getMoves(whiteTurn);
+    ChessMove match;
+    int matchCount = 0;
+    for (const auto& m : moves) {
+        if (m.getEndX() != endX || m.getEndY() != endY) continue;
+        const ChessPiece* p = board.getPiece(m.getStartX(), m.getStartY());
+        if (p == nullptr || p->getType() != pieceType) continue;
+        if (disambigFile >= 0 && m.getStartY() != disambigFile) continue;
+        if (disambigRank >= 0 && m.getStartX() != disambigRank) continue;
+        // For promotion moves, check that the promotion type matches.
+        if (promo != PAWN) {
+            if (m.getPromotion() != promo) continue;
+        } else {
+            // If no promotion specified, skip promotion moves.
+            if (m.getPromotion() != PAWN) continue;
+        }
+        match = m;
+        matchCount++;
+    }
+
+    if (matchCount == 1) return match;
+    return ChessMove();  // ambiguous or no match
+}
+
 ChessBoard& ChessGame::getPieceBoard() { return board; }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1254,9 +1254,14 @@ std::string ChessGame::toFen() const {
 ChessMove ChessGame::parseSan(const std::string& san) const {
     if (san.empty()) return ChessMove();
 
-    // Strip check/checkmate suffixes (+, #) for parsing.
+    // Strip and record check/checkmate suffixes (+, #).
     std::string s = san;
-    while (!s.empty() && (s.back() == '+' || s.back() == '#')) s.pop_back();
+    bool hasCheck = false, hasCheckmate = false;
+    while (!s.empty() && (s.back() == '+' || s.back() == '#')) {
+        if (s.back() == '#') hasCheckmate = true;
+        else hasCheck = true;
+        s.pop_back();
+    }
     if (s.empty()) return ChessMove();
 
     // Castling.
@@ -1315,10 +1320,12 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         s = s.substr(1);
     }
 
-    // Remove 'x' capture indicator.
+    // Remove and record 'x' capture indicator.
+    bool hasCapture = false;
     std::string cleaned;
     for (char c : s) {
-        if (c != 'x') cleaned += c;
+        if (c == 'x') hasCapture = true;
+        else cleaned += c;
     }
     s = cleaned;
 
@@ -1366,8 +1373,23 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         matchCount++;
     }
 
-    if (matchCount == 1) return match;
-    return ChessMove();  // ambiguous or no match
+    if (matchCount != 1) return ChessMove();  // ambiguous or no match
+
+    // Validate capture annotation: 'x' must correspond to an actual capture.
+    // A capture occurs when the destination is occupied, or for en passant
+    // (pawn moves diagonally to an empty square).
+    if (hasCapture) {
+        bool isCapture = (board.getPiece(endX, endY) != nullptr);
+        if (!isCapture && pieceType == PAWN && match.getStartY() != match.getEndY())
+            isCapture = true;  // en passant
+        if (!isCapture) return ChessMove();
+    }
+
+    // Note: check (+) and checkmate (#) annotations are accepted but not
+    // validated, as verification would require simulating the move. These
+    // are informational annotations per SAN convention.
+
+    return match;
 }
 
 ChessBoard& ChessGame::getPieceBoard() { return board; }

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -320,6 +320,8 @@ class ChessGame {
 
     std::string toFen() const;
 
+    ChessMove parseSan(const std::string& san) const;
+
     ChessBoard& getPieceBoard();
 
    private:

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1040,3 +1040,170 @@ TEST_CASE("ChessGame: FEN fullmove number increments after black moves", "[Chess
     fen = game.toFen();
     REQUIRE(fen.back() == '3');
 }
+
+// ============================================================================
+// SAN (Standard Algebraic Notation) Parsing
+// ============================================================================
+
+TEST_CASE("ChessGame: parseSan pawn move e4", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("e4");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartX() == 1);
+    REQUIRE(move.getStartY() == 4);
+    REQUIRE(move.getEndX() == 3);
+    REQUIRE(move.getEndY() == 4);
+}
+
+TEST_CASE("ChessGame: parseSan pawn move e3 (single push)", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("e3");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartX() == 1);
+    REQUIRE(move.getStartY() == 4);
+    REQUIRE(move.getEndX() == 2);
+    REQUIRE(move.getEndY() == 4);
+}
+
+TEST_CASE("ChessGame: parseSan knight move Nf3", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("Nf3");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartY() == 6);  // g-file knight
+    REQUIRE(move.getEndX() == 2);
+    REQUIRE(move.getEndY() == 5);
+}
+
+TEST_CASE("ChessGame: parseSan piece move with capture Bxc4", "[ChessGame][SAN]") {
+    ChessGame game;
+    // 1. e4 e5 2. Bc4 is needed first — but Bxc4 requires a capture target.
+    // Set up: 1. e4 d5 2. Bxd5? No, bishop can't reach d5 from f1 in one move.
+    // Use: 1. e4 d5 2. exd5 (pawn capture — not what we're testing).
+    // Better: custom board.
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(3, 5, new Bishop(WHITE, false, cb.b));  // Bishop on f4
+    cb.place(5, 3, new Pawn(BLACK, false, cb.b, 1));  // Pawn on d6
+    cb.activate();
+    ChessMove move = cb.game.parseSan("Bxd6");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getEndX() == 5);
+    REQUIRE(move.getEndY() == 3);
+}
+
+TEST_CASE("ChessGame: parseSan pawn capture exd5", "[ChessGame][SAN]") {
+    ChessGame game;
+    REQUIRE(game.makeMove(ChessMove(1, 4, 3, 4)));  // 1. e4
+    REQUIRE(game.makeMove(ChessMove(6, 3, 4, 3)));  // 1... d5
+    ChessMove move = game.parseSan("exd5");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartY() == 4);  // e-file
+    REQUIRE(move.getEndX() == 4);
+    REQUIRE(move.getEndY() == 3);    // d-file
+}
+
+TEST_CASE("ChessGame: parseSan kingside castling O-O", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.activate();
+    ChessMove move = cb.game.parseSan("O-O");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartX() == 0);
+    REQUIRE(move.getStartY() == 4);
+    REQUIRE(move.getEndX() == 0);
+    REQUIRE(move.getEndY() == 6);
+}
+
+TEST_CASE("ChessGame: parseSan queenside castling O-O-O", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.activate();
+    ChessMove move = cb.game.parseSan("O-O-O");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartX() == 0);
+    REQUIRE(move.getStartY() == 4);
+    REQUIRE(move.getEndX() == 0);
+    REQUIRE(move.getEndY() == 2);
+}
+
+TEST_CASE("ChessGame: parseSan promotion e8=Q", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(6, 4, new Pawn(WHITE, false, cb.b, 1));  // white pawn on e7
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    ChessMove move = cb.game.parseSan("e8=Q");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getEndX() == 7);
+    REQUIRE(move.getEndY() == 4);
+    REQUIRE(move.getPromotion() == QUEEN);
+}
+
+TEST_CASE("ChessGame: parseSan promotion with capture dxe8=N", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(6, 3, new Pawn(WHITE, false, cb.b, 1));  // white pawn on d7
+    cb.place(7, 4, new Knight(BLACK, false, cb.b));    // black knight on e8
+    cb.place(0, 0, new King(WHITE, cb.b));
+    cb.place(7, 7, new King(BLACK, cb.b));
+    cb.activate();
+    ChessMove move = cb.game.parseSan("dxe8=N");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartY() == 3);  // d-file
+    REQUIRE(move.getEndX() == 7);
+    REQUIRE(move.getEndY() == 4);    // e-file
+    REQUIRE(move.getPromotion() == KNIGHT);
+}
+
+TEST_CASE("ChessGame: parseSan knight disambiguation by file Nbd2", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(2, 5, new Knight(WHITE, false, cb.b));  // Knight on f3
+    cb.place(0, 1, new Knight(WHITE, false, cb.b));  // Knight on b1
+    cb.activate();
+    // Both knights can reach d2 (row 1, col 3). Nbd2 specifies b-file knight.
+    ChessMove move = cb.game.parseSan("Nbd2");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartY() == 1);  // b-file
+    REQUIRE(move.getEndX() == 1);
+    REQUIRE(move.getEndY() == 3);
+}
+
+TEST_CASE("ChessGame: parseSan knight disambiguation by rank N1d2", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(2, 5, new Knight(WHITE, false, cb.b));  // Knight on f3 (rank 3)
+    cb.place(0, 1, new Knight(WHITE, false, cb.b));  // Knight on b1 (rank 1)
+    cb.activate();
+    ChessMove move = cb.game.parseSan("N1d2");
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getStartX() == 0);  // rank 1
+    REQUIRE(move.getEndX() == 1);
+    REQUIRE(move.getEndY() == 3);
+}
+
+TEST_CASE("ChessGame: parseSan invalid move returns end sentinel", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("Qd4");  // Queen can't move to d4 from initial position
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan with check suffix Bb5+", "[ChessGame][SAN]") {
+    // The parser should ignore + and # suffixes.
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(3, 5, new Bishop(WHITE, false, cb.b));  // Bishop on f4
+    cb.activate();
+    ChessMove move = cb.game.parseSan("Bb8+");  // bishop to b8 (with check annotation)
+    // Check if b8 is reachable from f4: (3,5)→(7,1) — diagonal of 4. Yes!
+    REQUIRE(!move.isEnd());
+    REQUIRE(move.getEndX() == 7);
+    REQUIRE(move.getEndY() == 1);
+}

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1074,12 +1074,7 @@ TEST_CASE("ChessGame: parseSan knight move Nf3", "[ChessGame][SAN]") {
     REQUIRE(move.getEndY() == 5);
 }
 
-TEST_CASE("ChessGame: parseSan piece move with capture Bxc4", "[ChessGame][SAN]") {
-    ChessGame game;
-    // 1. e4 e5 2. Bc4 is needed first — but Bxc4 requires a capture target.
-    // Set up: 1. e4 d5 2. Bxd5? No, bishop can't reach d5 from f1 in one move.
-    // Use: 1. e4 d5 2. exd5 (pawn capture — not what we're testing).
-    // Better: custom board.
+TEST_CASE("ChessGame: parseSan piece capture Bxd6", "[ChessGame][SAN]") {
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
@@ -1194,16 +1189,24 @@ TEST_CASE("ChessGame: parseSan invalid move returns end sentinel", "[ChessGame][
     REQUIRE(move.isEnd());
 }
 
-TEST_CASE("ChessGame: parseSan with check suffix Bb5+", "[ChessGame][SAN]") {
-    // The parser should ignore + and # suffixes.
+TEST_CASE("ChessGame: parseSan with check suffix Bb8+", "[ChessGame][SAN]") {
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(3, 5, new Bishop(WHITE, false, cb.b));  // Bishop on f4
     cb.activate();
-    ChessMove move = cb.game.parseSan("Bb8+");  // bishop to b8 (with check annotation)
-    // Check if b8 is reachable from f4: (3,5)→(7,1) — diagonal of 4. Yes!
+    ChessMove move = cb.game.parseSan("Bb8+");
     REQUIRE(!move.isEnd());
     REQUIRE(move.getEndX() == 7);
     REQUIRE(move.getEndY() == 1);
+}
+
+TEST_CASE("ChessGame: parseSan rejects false capture annotation", "[ChessGame][SAN]") {
+    ChessGame game;
+    // Nxf3 is invalid — f3 is empty, so 'x' is a false capture claim
+    ChessMove move = game.parseSan("Nxf3");
+    REQUIRE(move.isEnd());
+    // But Nf3 (without x) works
+    move = game.parseSan("Nf3");
+    REQUIRE(!move.isEnd());
 }


### PR DESCRIPTION
## Summary

- Adds `ChessGame::parseSan(const std::string& san)` that parses standard algebraic notation by matching against legal moves
- Supports: pawn moves, piece moves, captures, castling (O-O, O-O-O), promotion (e8=Q), file/rank disambiguation (Nbd2, N1d2), check/checkmate suffixes
- Returns end sentinel for invalid or ambiguous input
- Updates Main.cpp: tries SAN first, falls back to LAN for backward compatibility
- Removes the commented-out `parseAlgMove` stub (Phase 6 TODO now complete)
- Updates help text to show SAN examples

## Tests

13 new SAN test cases (96 total, all passing):
- Pawn moves: e4, e3
- Knight move: Nf3
- Piece capture: Bxd6
- Pawn capture: exd5
- Castling: O-O, O-O-O
- Promotion: e8=Q, dxe8=N (capture + promotion)
- Disambiguation: Nbd2 (by file), N1d2 (by rank)
- Invalid move returns end sentinel
- Check suffix stripped: Bb8+

## Test plan

- [x] All 96 tests pass locally
- [ ] CI build + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)