### PR TITLE
chess: add JSON board state output (step 7b)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <sstream>
 
 using std::abs;
 
@@ -705,6 +706,7 @@ bool King::inCheck() const {
 }
 
 bool King::getMoved() const { return hasMoved; }
+void King::markMoved() { hasMoved = true; }
 
 PieceType King::getType() const { return KING; }
 
@@ -1254,6 +1256,145 @@ std::string ChessGame::toFen() const {
     return fen;
 }
 
+std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
+    std::istringstream ss(fen);
+    std::string placement, activeColor, castling, enPassant;
+    int halfmove = 0, fullmove = 1;
+    ss >> placement >> activeColor >> castling >> enPassant >> halfmove >> fullmove;
+
+    if (ss.fail()) {
+        fprintf(stderr, "fromFen: failed to parse FEN string: %s\n", fen.c_str());
+        std::abort();
+    }
+
+    auto game = std::unique_ptr<ChessGame>(new ChessGame());
+    game->setRules(false);
+
+    // Clear the board
+    for (int rx = 0; rx < 8; rx++)
+        for (int ry = 0; ry < 8; ry++)
+            game->setPiece(rx, ry, nullptr);
+
+    // 1. Parse piece placement (rank 8 = x=7 down to rank 1 = x=0)
+    int x = 7;
+    int y = 0;
+    for (char c : placement) {
+        if (c == '/') {
+            x--;
+            y = 0;
+        } else if (c >= '1' && c <= '8') {
+            y += (c - '0');
+        } else {
+            bool isWhite = (c >= 'A' && c <= 'Z');
+            char lower = isWhite ? static_cast<char>(c + 32) : c;
+            bool isKingSide = (y > 3);
+            // Pawn index based on column, matching ChessBoard constructor convention
+            int pawnIdx = isKingSide ? (y - 3) : (4 - y);
+
+            std::unique_ptr<ChessPiece> piece;
+            switch (lower) {
+                case 'p':
+                    piece = std::make_unique<Pawn>(isWhite, isKingSide, game->board, pawnIdx);
+                    break;
+                case 'r':
+                    piece = std::make_unique<Rook>(isWhite, isKingSide, game->board, 0);
+                    break;
+                case 'n':
+                    piece = std::make_unique<Knight>(isWhite, isKingSide, game->board, 0);
+                    break;
+                case 'b':
+                    piece = std::make_unique<Bishop>(isWhite, isKingSide, game->board, 0);
+                    break;
+                case 'q':
+                    piece = std::make_unique<Queen>(isWhite, game->board, 0, isKingSide);
+                    break;
+                case 'k':
+                    piece = std::make_unique<King>(isWhite, game->board);
+                    break;
+                default:
+                    fprintf(stderr, "fromFen: unexpected piece character '%c'\n", c);
+                    std::abort();
+            }
+            game->board.place(x, y, std::move(piece));
+            y++;
+        }
+    }
+
+    // 2. Active color
+    game->whiteTurn = (activeColor == "w");
+
+    // 3. Castling rights — pieces default to hasMoved=false.
+    //    Mark pieces as moved when they lack castling rights.
+    bool whiteKS = (castling.find('K') != std::string::npos);
+    bool whiteQS = (castling.find('Q') != std::string::npos);
+    bool blackKS = (castling.find('k') != std::string::npos);
+    bool blackQS = (castling.find('q') != std::string::npos);
+
+    // White king: if no castling rights at all, mark moved
+    if (!whiteKS && !whiteQS) {
+        ChessPiece* wk = game->board.getMoveablePiece(0, 4);
+        if (wk != nullptr && wk->getType() == KING)
+            dynamic_cast<King*>(wk)->markMoved();
+    }
+    if (!whiteKS) {
+        ChessPiece* wr = game->board.getMoveablePiece(0, 7);
+        if (wr != nullptr && wr->getType() == ROOK)
+            dynamic_cast<Rook*>(wr)->markMoved();
+    }
+    if (!whiteQS) {
+        ChessPiece* wr = game->board.getMoveablePiece(0, 0);
+        if (wr != nullptr && wr->getType() == ROOK)
+            dynamic_cast<Rook*>(wr)->markMoved();
+    }
+    // Black king: if no castling rights at all, mark moved
+    if (!blackKS && !blackQS) {
+        ChessPiece* bk = game->board.getMoveablePiece(7, 4);
+        if (bk != nullptr && bk->getType() == KING)
+            dynamic_cast<King*>(bk)->markMoved();
+    }
+    if (!blackKS) {
+        ChessPiece* br = game->board.getMoveablePiece(7, 7);
+        if (br != nullptr && br->getType() == ROOK)
+            dynamic_cast<Rook*>(br)->markMoved();
+    }
+    if (!blackQS) {
+        ChessPiece* br = game->board.getMoveablePiece(7, 0);
+        if (br != nullptr && br->getType() == ROOK)
+            dynamic_cast<Rook*>(br)->markMoved();
+    }
+
+    // 4. En passant target square
+    if (enPassant != "-") {
+        int epY = enPassant[0] - 'a';  // file
+        int epX = enPassant[1] - '1';  // rank (0-indexed)
+        // The pawn that double-pushed is one rank past the target:
+        // If it's black's turn (activeColor == "b"), white just pushed, pawn at epX+1.
+        // If it's white's turn (activeColor == "w"), black just pushed, pawn at epX-1.
+        int pawnX = (activeColor == "b") ? (epX + 1) : (epX - 1);
+        ChessPiece* p = game->board.getMoveablePiece(pawnX, epY);
+        if (p != nullptr && p->getType() == PAWN)
+            dynamic_cast<Pawn*>(p)->setEnPassant(true);
+    }
+
+    // 5. Halfmove clock
+    game->halfmoveClock = halfmove;
+
+    // 6. Fullmove number — derive history size so toFen() reproduces it.
+    //    toFen() computes: 1 + history.size() / 2
+    //    So: history.size() = (fullmove - 1) * 2 + (black to move ? 1 : 0)
+    int histSize = (fullmove - 1) * 2 + (activeColor == "b" ? 1 : 0);
+    game->history.clear();
+    for (int i = 0; i < histSize; i++)
+        game->history.push_back(ChessMove());
+
+    // 7. Initialize position history with the current position
+    game->positionHistory.clear();
+    game->setRules(true);
+    game->positionHistory.push_back(game->positionKey());
+
+    return game;
+}
+
 std::string ChessGame::positionKey() const {
     std::string fen = toFen();
     // Extract first 4 space-separated fields (piece placement, active color,
@@ -1288,6 +1429,99 @@ bool ChessGame::canClaimDraw() const {
 
 bool ChessGame::isAutomaticDraw() const {
     return halfmoveClock >= 150 || positionCount() >= 5;
+}
+
+std::string ChessGame::toJson() const {
+    std::string json = "{";
+
+    // fen
+    json += "\"fen\":\"" + toFen() + "\"";
+
+    // turn
+    json += ",\"turn\":\"";
+    json += whiteTurn ? "white" : "black";
+    json += "\"";
+
+    // board: 8x8 array, rank 8 (x=7) to rank 1 (x=0)
+    json += ",\"board\":[";
+    for (int x = 7; x >= 0; x--) {
+        json += "[";
+        for (int y = 0; y < 8; y++) {
+            const ChessPiece* p = board.getPiece(x, y);
+            if (p == nullptr) {
+                json += "null";
+            } else {
+                json += "{\"type\":\"";
+                switch (p->getType()) {
+                    case PAWN: json += "pawn"; break;
+                    case ROOK: json += "rook"; break;
+                    case KNIGHT: json += "knight"; break;
+                    case BISHOP: json += "bishop"; break;
+                    case QUEEN: json += "queen"; break;
+                    case KING: json += "king"; break;
+                }
+                json += "\",\"color\":\"";
+                json += p->getWhite() ? "white" : "black";
+                json += "\"}";
+            }
+            if (y < 7) json += ",";
+        }
+        json += "]";
+        if (x > 0) json += ",";
+    }
+    json += "]";
+
+    // legalMoves
+    bool currentTurn = whiteTurn;
+    std::vector<ChessMove> moves = getMoves(currentTurn);
+    json += ",\"legalMoves\":[";
+    for (size_t i = 0; i < moves.size(); i++) {
+        json += "\"";
+        json += moves[i].toString();
+        json += "\"";
+        if (i + 1 < moves.size()) json += ",";
+    }
+    json += "]";
+
+    // inCheck
+    bool inChk = board.checkCheck(currentTurn);
+    json += ",\"inCheck\":";
+    json += inChk ? "true" : "false";
+
+    // isCheckmate
+    json += ",\"isCheckmate\":";
+    json += checkmate(currentTurn) ? "true" : "false";
+
+    // isStalemate
+    json += ",\"isStalemate\":";
+    json += stalemate(currentTurn) ? "true" : "false";
+
+    // canClaimDraw
+    json += ",\"canClaimDraw\":";
+    json += canClaimDraw() ? "true" : "false";
+
+    // isAutomaticDraw
+    json += ",\"isAutomaticDraw\":";
+    json += isAutomaticDraw() ? "true" : "false";
+
+    // halfmoveClock
+    json += ",\"halfmoveClock\":" + std::to_string(halfmoveClock);
+
+    // fullmoveNumber
+    json += ",\"fullmoveNumber\":" + std::to_string(1 + static_cast<int>(history.size()) / 2);
+
+    // moveHistory
+    json += ",\"moveHistory\":[";
+    for (size_t i = 0; i < history.size(); i++) {
+        json += "\"";
+        json += history[i].toString();
+        json += "\"";
+        if (i + 1 < history.size()) json += ",";
+    }
+    json += "]";
+
+    json += "}";
+    return json;
 }
 
 ChessBoard& ChessGame::getPieceBoard() { return board; }

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1263,8 +1263,7 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     ss >> placement >> activeColor >> castling >> enPassant >> halfmove >> fullmove;
 
     if (ss.fail()) {
-        fprintf(stderr, "fromFen: failed to parse FEN string: %s\n", fen.c_str());
-        std::abort();
+        return nullptr;
     }
 
     auto game = std::unique_ptr<ChessGame>(new ChessGame());
@@ -1312,8 +1311,7 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
                     piece = std::make_unique<King>(isWhite, game->board);
                     break;
                 default:
-                    fprintf(stderr, "fromFen: unexpected piece character '%c'\n", c);
-                    std::abort();
+                    return nullptr;  // invalid piece character
             }
             game->board.place(x, y, std::move(piece));
             y++;

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -184,6 +184,7 @@ class King : public ChessPiece {
     bool canMove(int x, int y, bool chkchk = true) const override;
     std::vector<ChessMove> getMoves() const override;
     bool getMoved() const;
+    void markMoved();
     bool move(int x, int y) override;
     bool inCheck() const;
     PieceType getType() const override;
@@ -324,9 +325,13 @@ class ChessGame {
     const std::vector<ChessMove>& getHistory() const;
 
     std::string toFen() const;
+    static std::unique_ptr<ChessGame> fromFen(const std::string& fen);
 
     bool canClaimDraw() const;
     bool isAutomaticDraw() const;
+
+    /** Returns a JSON string representing the full game state. */
+    std::string toJson() const;
 
     ChessBoard& getPieceBoard();
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1154,3 +1154,194 @@ TEST_CASE("ChessGame: pawn move resets 50-move counter for draw", "[ChessGame][D
     // After pawn move, draw definitely not claimable
     REQUIRE_FALSE(game.canClaimDraw());
 }
+
+// ============================================================================
+// JSON Board State (toJson)
+// ============================================================================
+
+TEST_CASE("toJson: initial position contains correct FEN", "[ChessGame][JSON]") {
+    ChessGame game;
+    std::string json = game.toJson();
+    REQUIRE(json.find("\"fen\":\"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\"") !=
+            std::string::npos);
+}
+
+TEST_CASE("toJson: initial position has turn white", "[ChessGame][JSON]") {
+    ChessGame game;
+    std::string json = game.toJson();
+    REQUIRE(json.find("\"turn\":\"white\"") != std::string::npos);
+}
+
+TEST_CASE("toJson: initial position has 20 legal moves", "[ChessGame][JSON]") {
+    ChessGame game;
+    std::string json = game.toJson();
+    // Count occurrences of move strings in legalMoves array
+    auto start = json.find("\"legalMoves\":[");
+    REQUIRE(start != std::string::npos);
+    auto end = json.find(']', start + 14);
+    REQUIRE(end != std::string::npos);
+    std::string movesStr = json.substr(start + 14, end - start - 14);
+    // Count commas + 1 = number of elements (if non-empty)
+    int count = movesStr.empty() ? 0 : 1;
+    for (char c : movesStr) {
+        if (c == ',') count++;
+    }
+    REQUIRE(count == 20);
+}
+
+TEST_CASE("toJson: after 1.e4 has turn black and en passant in FEN", "[ChessGame][JSON]") {
+    ChessGame game;
+    game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4
+    std::string json = game.toJson();
+    REQUIRE(json.find("\"turn\":\"black\"") != std::string::npos);
+    REQUIRE(json.find("e3") != std::string::npos);  // en passant square in FEN
+}
+
+TEST_CASE("toJson: board array has correct pieces at initial position", "[ChessGame][JSON]") {
+    ChessGame game;
+    std::string json = game.toJson();
+    // Black rook should appear
+    REQUIRE(json.find("{\"type\":\"rook\",\"color\":\"black\"}") != std::string::npos);
+    // White pawn should appear
+    REQUIRE(json.find("{\"type\":\"pawn\",\"color\":\"white\"}") != std::string::npos);
+    // White king should appear
+    REQUIRE(json.find("{\"type\":\"king\",\"color\":\"white\"}") != std::string::npos);
+    // Null squares (empty) should appear
+    REQUIRE(json.find("null") != std::string::npos);
+}
+
+TEST_CASE("toJson: checkmate position has isCheckmate true", "[ChessGame][JSON]") {
+    // Scholar's mate: 1. e4 e5 2. Bc4 Nc6 3. Qh5 Nf6 4. Qxf7#
+    ChessGame game;
+    game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4
+    game.makeMove(ChessMove(6, 4, 4, 4));  // e7-e5
+    game.makeMove(ChessMove(0, 5, 3, 2));  // Bf1-c4
+    game.makeMove(ChessMove(7, 1, 5, 2));  // Nb8-c6
+    game.makeMove(ChessMove(0, 3, 4, 7));  // Qd1-h5
+    game.makeMove(ChessMove(7, 6, 5, 5));  // Ng8-f6
+    game.makeMove(ChessMove(4, 7, 6, 5));  // Qh5xf7#
+    std::string json = game.toJson();
+    REQUIRE(json.find("\"isCheckmate\":true") != std::string::npos);
+    REQUIRE(json.find("\"inCheck\":true") != std::string::npos);
+}
+
+TEST_CASE("toJson: moveHistory grows after moves", "[ChessGame][JSON]") {
+    ChessGame game;
+    std::string json = game.toJson();
+    REQUIRE(json.find("\"moveHistory\":[]") != std::string::npos);
+
+    game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4
+    json = game.toJson();
+    REQUIRE(json.find("\"moveHistory\":[\"e2-e4\"]") != std::string::npos);
+
+    game.makeMove(ChessMove(6, 4, 4, 4));  // e7-e5
+    json = game.toJson();
+    REQUIRE(json.find("\"moveHistory\":[\"e2-e4\",\"e7-e5\"]") != std::string::npos);
+}
+
+// ============================================================================
+// FEN Deserialization
+// ============================================================================
+
+TEST_CASE("ChessGame::fromFen: round-trip initial position", "[ChessGame][FEN]") {
+    ChessGame game;
+    std::string originalFen = game.toFen();
+    auto loaded = ChessGame::fromFen(originalFen);
+    REQUIRE(loaded->toFen() == originalFen);
+}
+
+TEST_CASE("ChessGame::fromFen: mid-game position pieces placed correctly", "[ChessGame][FEN]") {
+    // Sicilian Defense after 1. e4 c5
+    std::string fen = "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2";
+    auto game = ChessGame::fromFen(fen);
+    // White pawn on e4 (x=3, y=4)
+    const ChessPiece* wp = game->getPiece(3, 4);
+    REQUIRE(wp != nullptr);
+    REQUIRE(wp->getType() == PAWN);
+    REQUIRE(wp->getWhite() == true);
+    // Black pawn on c5 (x=4, y=2)
+    const ChessPiece* bp = game->getPiece(4, 2);
+    REQUIRE(bp != nullptr);
+    REQUIRE(bp->getType() == PAWN);
+    REQUIRE(bp->getWhite() == false);
+    // Empty square at e2 (x=1, y=4) — pawn moved away
+    REQUIRE(game->getPiece(1, 4) == nullptr);
+    // FEN round-trips
+    REQUIRE(game->toFen() == fen);
+}
+
+TEST_CASE("ChessGame::fromFen: preserves active color (black to move)", "[ChessGame][FEN]") {
+    std::string fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->getTurn() == BLACK);
+    REQUIRE(game->toFen() == fen);
+}
+
+TEST_CASE("ChessGame::fromFen: preserves partial castling rights", "[ChessGame][FEN]") {
+    // Only white queenside and black kingside castling available
+    std::string fen = "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w Qk - 0 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->toFen() == fen);
+    // Verify: white king unmoved, white kingside rook moved, white queenside rook unmoved
+    const ChessPiece* wk = game->getPiece(0, 4);
+    REQUIRE(wk != nullptr);
+    REQUIRE(wk->getType() == KING);
+    const King* whiteKing = dynamic_cast<const King*>(wk);
+    REQUIRE_FALSE(whiteKing->getMoved());
+    // White kingside rook at (0,7) should be marked moved (no K right)
+    const ChessPiece* wkr = game->getPiece(0, 7);
+    REQUIRE(wkr != nullptr);
+    REQUIRE(wkr->getType() == ROOK);
+    const Rook* whiteKSRook = dynamic_cast<const Rook*>(wkr);
+    REQUIRE(whiteKSRook->getMoved());
+    // White queenside rook at (0,0) should be unmoved (Q right present)
+    const ChessPiece* wqr = game->getPiece(0, 0);
+    REQUIRE(wqr != nullptr);
+    const Rook* whiteQSRook = dynamic_cast<const Rook*>(wqr);
+    REQUIRE_FALSE(whiteQSRook->getMoved());
+}
+
+TEST_CASE("ChessGame::fromFen: preserves en passant target square", "[ChessGame][FEN]") {
+    // After 1. e4, en passant target is e3
+    std::string fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->toFen() == fen);
+    // The white pawn at e4 (x=3, y=4) should have enPassant flag set
+    const ChessPiece* p = game->getPiece(3, 4);
+    REQUIRE(p != nullptr);
+    REQUIRE(p->getType() == PAWN);
+    const Pawn* pawn = dynamic_cast<const Pawn*>(p);
+    REQUIRE(pawn->getEnPassant());
+}
+
+TEST_CASE("ChessGame::fromFen: preserves halfmove clock", "[ChessGame][FEN]") {
+    std::string fen = "rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq - 1 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->toFen() == fen);
+}
+
+TEST_CASE("ChessGame::fromFen: preserves fullmove number via toFen", "[ChessGame][FEN]") {
+    std::string fen = "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->toFen() == fen);
+}
+
+TEST_CASE("ChessGame::fromFen: no castling rights (dash)", "[ChessGame][FEN]") {
+    std::string fen = "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w - - 0 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game->toFen() == fen);
+    // Both kings should be marked as moved
+    const King* wk = dynamic_cast<const King*>(game->getPiece(0, 4));
+    REQUIRE(wk->getMoved());
+    const King* bk = dynamic_cast<const King*>(game->getPiece(7, 4));
+    REQUIRE(bk->getMoved());
+}
+
+TEST_CASE("ChessGame::fromFen: legal moves from loaded position work", "[ChessGame][FEN]") {
+    // Scholar's mate setup: white to play Qxf7#
+    std::string fen = "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3";
+    auto game = ChessGame::fromFen(fen);
+    // White queen on f3 (x=2, y=5) captures f7 (x=6, y=5) — should be checkmate
+    REQUIRE(game->makeMove(ChessMove(2, 5, 6, 5)));
+    REQUIRE(game->checkmate(BLACK));
+}


### PR DESCRIPTION
## Summary

- Add `ChessGame::toJson()` that produces a structured JSON representation of the full game state (FEN, turn, 8x8 board array, legal moves, check/checkmate/stalemate flags, draw detection, clocks, move history). JSON is built manually with no external library dependency.
- Add `ChessGame::fromFen()` for constructing a game state from a FEN string, with `King::markMoved()` helper for setting castling state correctly.
- 7 new JSON tests covering: initial position FEN, turn, 20 legal moves, post-move state (turn flip + en passant), board array piece spot-checks, checkmate detection (Scholar's mate), and move history growth.
- 9 new fromFen tests covering: round-trip serialization, piece placement, active color, partial castling rights, en passant target, halfmove clock, fullmove number, no-castling-rights case, and legal move execution from loaded positions.

## Test plan

- [x] All 105 tests pass (`chess_tests`)
- [x] JSON tests verify string content via `std::string::find` (no JSON parser needed)
- [x] Checkmate scenario uses Scholar's mate for deterministic verification
- [x] fromFen round-trip tests confirm FEN fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)