### PR TITLE
chess: position identity ignores irrelevant ep targets (step 8b)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1534,13 +1534,55 @@ std::string ChessGame::positionKey() const {
     // castling, en passant) — halfmove clock and fullmove number are not part
     // of position identity.
     int spaces = 0;
+    size_t end = fen.size();
     for (size_t i = 0; i < fen.size(); i++) {
         if (fen[i] == ' ') {
             spaces++;
-            if (spaces == 4) return fen.substr(0, i);
+            if (spaces == 4) { end = i; break; }
         }
     }
-    return fen;  // fallback (shouldn't happen)
+    std::string key = fen.substr(0, end);
+
+    // Per SPEC 4.3: the en passant target is only part of position identity
+    // when a fully legal en passant capture exists. If no legal capture is
+    // available, replace the ep field with "-" so positions match.
+    // Find the ep field (after 3rd space).
+    size_t epStart = 0;
+    int sp = 0;
+    for (size_t i = 0; i < key.size(); i++) {
+        if (key[i] == ' ') {
+            sp++;
+            if (sp == 3) { epStart = i + 1; break; }
+        }
+    }
+    std::string ep = key.substr(epStart);
+    if (ep != "-") {
+        // Check if any legal en passant capture exists.
+        bool hasLegalEp = false;
+        int epY = ep[0] - 'a';  // file
+        int epX = ep[1] - '1';  // rank (0-indexed)
+        // The capturing pawn must be on the same rank as the pawn that double-pushed,
+        // i.e., one rank "behind" the ep target from the capturing side's perspective.
+        // If white to move, ep target is on rank 5 (epX=5), capturing pawn on rank 4.
+        // If black to move, ep target is on rank 2 (epX=2), capturing pawn on rank 3.
+        int captRank = whiteTurn ? (epX - 1) : (epX + 1);
+        for (int dy : {-1, 1}) {
+            int adjFile = epY + dy;
+            if (adjFile < 0 || adjFile > 7) continue;
+            const ChessPiece* p = board.getPiece(captRank, adjFile);
+            if (p != nullptr && p->getType() == PAWN && p->getWhite() == whiteTurn) {
+                // Check if the en passant capture is legal (doesn't leave king in check).
+                if (p->canMove(epX, epY)) {
+                    hasLegalEp = true;
+                    break;
+                }
+            }
+        }
+        if (!hasLegalEp) {
+            key = key.substr(0, epStart) + "-";
+        }
+    }
+    return key;
 }
 
 // O(n) scan over full history. Could be improved by only scanning back

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -612,6 +612,10 @@ bool King::canMove(int x, int y, bool chkchk) const {
             // King always starts at column 4 (hard-coded assumption).
             // Rook column: (7 + 7*sign)/2 -> kingside=7, queenside=0.
             int sign = (y - cy) / 2;
+            bool isKingSide = (sign == 1);
+
+            // Check independent castling right flag.
+            if (!board.getCastlingRight(isWhite, isKingSide)) return false;
 
             if (board.getPiece(cx, 4 + sign) == nullptr &&
                 board.getPiece(cx, 4 + 2 * sign) == nullptr &&
@@ -890,6 +894,18 @@ ChessBoard::ChessBoard() {
 
 ChessBoard::~ChessBoard() {}  // unique_ptrs in grid[] clean up automatically
 
+bool ChessBoard::getCastlingRight(bool isWhite, bool isKingSide) const {
+    return castlingRights[isWhite ? 0 : 1][isKingSide ? 0 : 1];
+}
+
+void ChessBoard::clearCastlingRight(bool isWhite, bool isKingSide) {
+    castlingRights[isWhite ? 0 : 1][isKingSide ? 0 : 1] = false;
+}
+
+void ChessBoard::setCastlingRight(bool isWhite, bool isKingSide, bool value) {
+    castlingRights[isWhite ? 0 : 1][isKingSide ? 0 : 1] = value;
+}
+
 const char* ChessBoard::toString() {
     // Layout: 8 ranks x 4 display rows/rank + 1 border row = 33 rows.
     // Each row: 8 squares x 5 chars/square + 1 border col = 41 chars + newline = 42.
@@ -1120,6 +1136,26 @@ bool ChessGame::makeMove(const ChessMove& cm) {
             else
                 halfmoveClock++;
             bool movedColor = whiteTurn;  // capture before flip
+
+            // Update independent castling rights.
+            // King move: clear both rights for that color.
+            if (piece->getType() == KING) {
+                board.clearCastlingRight(movedColor, true);
+                board.clearCastlingRight(movedColor, false);
+            }
+            // Rook move from starting square: clear that side's right.
+            if (piece->getType() == ROOK) {
+                int sx = cm.getStartX(), sy = cm.getStartY();
+                int homeRank = movedColor ? 0 : 7;
+                if (sx == homeRank && sy == 7) board.clearCastlingRight(movedColor, true);
+                if (sx == homeRank && sy == 0) board.clearCastlingRight(movedColor, false);
+            }
+            // Capture on a rook's starting square: clear that side's right.
+            int ex = cm.getEndX(), ey = cm.getEndY();
+            if (ex == 0 && ey == 7) board.clearCastlingRight(true, true);
+            if (ex == 0 && ey == 0) board.clearCastlingRight(true, false);
+            if (ex == 7 && ey == 7) board.clearCastlingRight(false, true);
+            if (ex == 7 && ey == 0) board.clearCastlingRight(false, false);
             // Handle pawn promotion: replace pawn with requested piece type.
             // Write directly to board.grid (ChessGame is a friend of ChessBoard)
             // rather than routing through setPiece() to avoid the rulesOn guard.
@@ -1200,42 +1236,12 @@ std::string ChessGame::toFen() const {
     // 2. Active color
     fen += whiteTurn ? " w" : " b";
 
-    // 3. Castling availability
+    // 3. Castling availability — uses independent flags on ChessBoard.
     std::string castling;
-    // White kingside: king at (0,4) unmoved, rook at (0,7) unmoved
-    const ChessPiece* wk = board.getPiece(0, 4);
-    if (wk != nullptr && wk->getType() == KING && wk->getWhite()) {
-        const King* king = dynamic_cast<const King*>(wk);
-        if (!king->getMoved()) {
-            const ChessPiece* wr = board.getPiece(0, 7);
-            if (wr != nullptr && wr->getType() == ROOK && wr->getWhite()) {
-                const Rook* rook = dynamic_cast<const Rook*>(wr);
-                if (!rook->getMoved()) castling += 'K';
-            }
-            const ChessPiece* wqr = board.getPiece(0, 0);
-            if (wqr != nullptr && wqr->getType() == ROOK && wqr->getWhite()) {
-                const Rook* rook = dynamic_cast<const Rook*>(wqr);
-                if (!rook->getMoved()) castling += 'Q';
-            }
-        }
-    }
-    // Black kingside: king at (7,4) unmoved, rook at (7,7) unmoved
-    const ChessPiece* bk = board.getPiece(7, 4);
-    if (bk != nullptr && bk->getType() == KING && !bk->getWhite()) {
-        const King* king = dynamic_cast<const King*>(bk);
-        if (!king->getMoved()) {
-            const ChessPiece* br = board.getPiece(7, 7);
-            if (br != nullptr && br->getType() == ROOK && !br->getWhite()) {
-                const Rook* rook = dynamic_cast<const Rook*>(br);
-                if (!rook->getMoved()) castling += 'k';
-            }
-            const ChessPiece* bqr = board.getPiece(7, 0);
-            if (bqr != nullptr && bqr->getType() == ROOK && !bqr->getWhite()) {
-                const Rook* rook = dynamic_cast<const Rook*>(bqr);
-                if (!rook->getMoved()) castling += 'q';
-            }
-        }
-    }
+    if (board.getCastlingRight(true, true)) castling += 'K';
+    if (board.getCastlingRight(true, false)) castling += 'Q';
+    if (board.getCastlingRight(false, true)) castling += 'k';
+    if (board.getCastlingRight(false, false)) castling += 'q';
     fen += ' ';
     fen += castling.empty() ? "-" : castling;
 
@@ -1479,45 +1485,16 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     // 2. Active color
     game->whiteTurn = (activeColor == "w");
 
-    // 3. Castling rights — pieces default to hasMoved=false.
-    //    Mark pieces as moved when they lack castling rights.
-    bool whiteKS = (castling.find('K') != std::string::npos);
-    bool whiteQS = (castling.find('Q') != std::string::npos);
-    bool blackKS = (castling.find('k') != std::string::npos);
-    bool blackQS = (castling.find('q') != std::string::npos);
-
-    // White king: if no castling rights at all, mark moved
-    if (!whiteKS && !whiteQS) {
-        ChessPiece* wk = game->board.getMoveablePiece(0, 4);
-        if (wk != nullptr && wk->getType() == KING)
-            dynamic_cast<King*>(wk)->markMoved();
-    }
-    if (!whiteKS) {
-        ChessPiece* wr = game->board.getMoveablePiece(0, 7);
-        if (wr != nullptr && wr->getType() == ROOK)
-            dynamic_cast<Rook*>(wr)->markMoved();
-    }
-    if (!whiteQS) {
-        ChessPiece* wr = game->board.getMoveablePiece(0, 0);
-        if (wr != nullptr && wr->getType() == ROOK)
-            dynamic_cast<Rook*>(wr)->markMoved();
-    }
-    // Black king: if no castling rights at all, mark moved
-    if (!blackKS && !blackQS) {
-        ChessPiece* bk = game->board.getMoveablePiece(7, 4);
-        if (bk != nullptr && bk->getType() == KING)
-            dynamic_cast<King*>(bk)->markMoved();
-    }
-    if (!blackKS) {
-        ChessPiece* br = game->board.getMoveablePiece(7, 7);
-        if (br != nullptr && br->getType() == ROOK)
-            dynamic_cast<Rook*>(br)->markMoved();
-    }
-    if (!blackQS) {
-        ChessPiece* br = game->board.getMoveablePiece(7, 0);
-        if (br != nullptr && br->getType() == ROOK)
-            dynamic_cast<Rook*>(br)->markMoved();
-    }
+    // 3. Castling rights — set independent flags on ChessBoard.
+    //    Default is all true; clear the ones not present in the FEN string.
+    if (castling.find('K') == std::string::npos)
+        game->board.clearCastlingRight(true, true);
+    if (castling.find('Q') == std::string::npos)
+        game->board.clearCastlingRight(true, false);
+    if (castling.find('k') == std::string::npos)
+        game->board.clearCastlingRight(false, true);
+    if (castling.find('q') == std::string::npos)
+        game->board.clearCastlingRight(false, false);
 
     // 4. En passant target square
     if (enPassant != "-") {

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -225,9 +225,19 @@ class ChessBoard {
 
     const char* toString();
 
+    /**
+     * Returns whether the given castling right is still available.
+     * @param isWhite true for White, false for Black.
+     * @param isKingSide true for kingside, false for queenside.
+     */
+    bool getCastlingRight(bool isWhite, bool isKingSide) const;
+    void setCastlingRight(bool isWhite, bool isKingSide, bool value);
+
     friend class ChessGame;
 
    private:
+    bool castlingRights[2][2] = {{true, true}, {true, true}};  // [white/black][kingside/queenside]
+    void clearCastlingRight(bool isWhite, bool isKingSide);
     std::unique_ptr<ChessPiece> grid[8][8];
     std::unique_ptr<ChessPiece> movePiece(ChessMove move);
     ChessPiece* getMoveablePiece(int x, int y);

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1421,6 +1421,48 @@ TEST_CASE("ChessGame: pawn move resets 50-move counter for draw", "[ChessGame][D
 }
 
 // ============================================================================
+// Position identity for repetition detection
+// ============================================================================
+
+TEST_CASE("ChessGame: position identity ignores ep square when no legal capture exists",
+          "[ChessGame][Draw]") {
+    // The standard initial position + 1.e4 creates an ep target on e3, but no
+    // black pawn is on d4 or f4 to capture it. So for position identity, the ep
+    // field should be ignored.
+    //
+    // Play: 1. e4 Nc6  2. Nf3 Nb8  3. Ng1 Nc6  4. Ng1 Nb8  5. ...
+    // After 2. Nf3 Nb8: board = initial except e-pawn on e4, black to move
+    // After 4. Ng1 Nb8: same board, black to move = second occurrence
+    //
+    // But we need a third occurrence. Use a different approach:
+    // Start from a FEN where a double push just happened (ep target set) but
+    // no enemy pawn can capture. Then cycle to repeat.
+
+    // Use fromFen to set up: pawn already on a4, black pawn on h7,
+    // black to move, ep=a3 (irrelevant since no black pawn near a-file).
+    auto game = ChessGame::fromFen("4k3/7p/8/8/P7/8/8/4K3 b - a3 0 1");
+    REQUIRE(game != nullptr);
+
+    // Position 1 (from FEN): kings e1/e8, white pawn a4, black pawn h7, black to move
+    // Note: ep=a3 in FEN but since no legal capture, position key should use "-"
+
+    // 1... Kd8  2. Kd1  3... Ke8  4. Ke1 → position 2 (same board, black to move)
+    REQUIRE(game->makeMove(ChessMove(7, 4, 7, 3)));  // 1... Kd8
+    REQUIRE(game->makeMove(ChessMove(0, 4, 0, 3)));  // 2. Kd1
+    REQUIRE(game->makeMove(ChessMove(7, 3, 7, 4)));  // 2... Ke8
+    REQUIRE(game->makeMove(ChessMove(0, 3, 0, 4)));  // 3. Ke1
+    // Position 2: same as 1 (black to move), no ep target
+    REQUIRE(game->makeMove(ChessMove(7, 4, 7, 3)));  // 3... Kd8
+    REQUIRE(game->makeMove(ChessMove(0, 4, 0, 3)));  // 4. Kd1
+    REQUIRE(game->makeMove(ChessMove(7, 3, 7, 4)));  // 4... Ke8
+    REQUIRE(game->makeMove(ChessMove(0, 3, 0, 4)));  // 5. Ke1
+    // Position 3: same as 1 and 2
+
+    // With correct ep handling: all three positions identical → threefold repetition
+    REQUIRE(game->canClaimDraw());
+}
+
+// ============================================================================
 // JSON Board State (toJson)
 // ============================================================================
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -26,6 +26,11 @@ struct CustomBoard {
         game.setRules(false);
         for (int x = 0; x < 8; x++)
             for (int y = 0; y < 8; y++) game.setPiece(x, y, nullptr);
+        // Clear all castling rights — tests that need castling must set them.
+        b.setCastlingRight(true, true, false);
+        b.setCastlingRight(true, false, false);
+        b.setCastlingRight(false, true, false);
+        b.setCastlingRight(false, false, false);
     }
 
     void place(int x, int y, ChessPiece* piece) {
@@ -636,6 +641,7 @@ TEST_CASE("King: kingside castling moves king to g-file and rook to f-file", "[K
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, true, true);  // white kingside
     cb.activate();
 
     REQUIRE(cb.game.getPiece(0, 4)->canMove(0, 6));
@@ -651,6 +657,7 @@ TEST_CASE("King: queenside castling moves king to c-file and rook to d-file", "[
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(0, 0, new Rook(WHITE, false, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, false, true);  // white queenside
     cb.activate();
 
     REQUIRE(cb.game.getPiece(0, 4)->canMove(0, 2));
@@ -666,6 +673,7 @@ TEST_CASE("King: cannot castle after king has moved", "[King]") {
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(7, 0, new Rook(BLACK, false, cb.b));
+    cb.b.setCastlingRight(true, true, true);  // white kingside
     cb.activate();
 
     cb.game.makeMove(ChessMove(0, 4, 0, 3));  // king moves
@@ -682,6 +690,7 @@ TEST_CASE("King: cannot castle through attacked square", "[King]") {
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
     cb.place(5, 5, new Rook(BLACK, false, cb.b));  // attacks (0,5) on f-file
     cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, true, true);  // white kingside
     cb.activate();
 
     REQUIRE(!cb.game.getPiece(0, 4)->canMove(0, 6));
@@ -693,6 +702,7 @@ TEST_CASE("King: cannot castle if rook has moved", "[King]") {
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(7, 0, new Rook(BLACK, false, cb.b));
+    cb.b.setCastlingRight(true, true, true);  // white kingside
     cb.activate();
 
     cb.game.makeMove(ChessMove(0, 7, 0, 6));  // rook moves
@@ -1004,6 +1014,8 @@ TEST_CASE("ChessGame: FEN castling rights removed after king moves", "[ChessGame
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(0, 0, new Rook(WHITE, false, cb.b));
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.b.setCastlingRight(true, true, true);
+    cb.b.setCastlingRight(true, false, true);
     cb.activate();
     // Move white king
     REQUIRE(cb.game.makeMove(ChessMove(0, 4, 0, 5)));
@@ -1027,6 +1039,8 @@ TEST_CASE("ChessGame: FEN castling rights after only kingside rook moves", "[Che
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(0, 0, new Rook(WHITE, false, cb.b));
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.b.setCastlingRight(true, true, true);
+    cb.b.setCastlingRight(true, false, true);
     cb.activate();
     // Move kingside rook
     REQUIRE(cb.game.makeMove(ChessMove(0, 7, 1, 7)));
@@ -1182,6 +1196,7 @@ TEST_CASE("ChessGame: parseSan kingside castling O-O", "[ChessGame][SAN]") {
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(0, 7, new Rook(WHITE, true, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, true, true);
     cb.activate();
     ChessMove move = cb.game.parseSan("O-O");
     REQUIRE(!move.isEnd());
@@ -1196,6 +1211,7 @@ TEST_CASE("ChessGame: parseSan queenside castling O-O-O", "[ChessGame][SAN]") {
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(0, 0, new Rook(WHITE, false, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, false, true);
     cb.activate();
     ChessMove move = cb.game.parseSan("O-O-O");
     REQUIRE(!move.isEnd());
@@ -1531,23 +1547,11 @@ TEST_CASE("ChessGame::fromFen: preserves partial castling rights", "[ChessGame][
     std::string fen = "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w Qk - 0 1";
     auto game = ChessGame::fromFen(fen);
     REQUIRE(game->toFen() == fen);
-    // Verify: white king unmoved, white kingside rook moved, white queenside rook unmoved
-    const ChessPiece* wk = game->getPiece(0, 4);
-    REQUIRE(wk != nullptr);
-    REQUIRE(wk->getType() == KING);
-    const King* whiteKing = dynamic_cast<const King*>(wk);
-    REQUIRE_FALSE(whiteKing->getMoved());
-    // White kingside rook at (0,7) should be marked moved (no K right)
-    const ChessPiece* wkr = game->getPiece(0, 7);
-    REQUIRE(wkr != nullptr);
-    REQUIRE(wkr->getType() == ROOK);
-    const Rook* whiteKSRook = dynamic_cast<const Rook*>(wkr);
-    REQUIRE(whiteKSRook->getMoved());
-    // White queenside rook at (0,0) should be unmoved (Q right present)
-    const ChessPiece* wqr = game->getPiece(0, 0);
-    REQUIRE(wqr != nullptr);
-    const Rook* whiteQSRook = dynamic_cast<const Rook*>(wqr);
-    REQUIRE_FALSE(whiteQSRook->getMoved());
+    ChessBoard& b = game->getPieceBoard();
+    REQUIRE(!b.getCastlingRight(true, true));   // no K
+    REQUIRE(b.getCastlingRight(true, false));    // Q present
+    REQUIRE(b.getCastlingRight(false, true));    // k present
+    REQUIRE(!b.getCastlingRight(false, false));  // no q
 }
 
 TEST_CASE("ChessGame::fromFen: preserves en passant target square", "[ChessGame][FEN]") {
@@ -1579,11 +1583,12 @@ TEST_CASE("ChessGame::fromFen: no castling rights (dash)", "[ChessGame][FEN]") {
     std::string fen = "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w - - 0 1";
     auto game = ChessGame::fromFen(fen);
     REQUIRE(game->toFen() == fen);
-    // Both kings should be marked as moved
-    const King* wk = dynamic_cast<const King*>(game->getPiece(0, 4));
-    REQUIRE(wk->getMoved());
-    const King* bk = dynamic_cast<const King*>(game->getPiece(7, 4));
-    REQUIRE(bk->getMoved());
+    // Castling flags should all be cleared
+    ChessBoard& b = game->getPieceBoard();
+    REQUIRE(!b.getCastlingRight(true, true));
+    REQUIRE(!b.getCastlingRight(true, false));
+    REQUIRE(!b.getCastlingRight(false, true));
+    REQUIRE(!b.getCastlingRight(false, false));
 }
 
 TEST_CASE("ChessGame::fromFen: legal moves from loaded position work", "[ChessGame][FEN]") {
@@ -1593,4 +1598,123 @@ TEST_CASE("ChessGame::fromFen: legal moves from loaded position work", "[ChessGa
     // White queen on f3 (x=2, y=5) captures f7 (x=6, y=5) — should be checkmate
     REQUIRE(game->makeMove(ChessMove(2, 5, 6, 5)));
     REQUIRE(game->checkmate(BLACK));
+}
+
+// ============================================================================
+// Independent castling rights
+// ============================================================================
+
+TEST_CASE("ChessBoard: getCastlingRight returns initial rights", "[ChessBoard][Castling]") {
+    ChessGame game;
+    ChessBoard& b = game.getPieceBoard();
+    REQUIRE(b.getCastlingRight(true, true));    // white kingside
+    REQUIRE(b.getCastlingRight(true, false));   // white queenside
+    REQUIRE(b.getCastlingRight(false, true));   // black kingside
+    REQUIRE(b.getCastlingRight(false, false));  // black queenside
+}
+
+TEST_CASE("ChessGame: castling right lost when rook captured on starting square",
+          "[ChessGame][Castling]") {
+    // White rook on a1, Black rook on a8, kings on e-file.
+    // White plays Rxa8 — captures the black queenside rook on its starting square.
+    // Black should lose queenside castling right.
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));  // a1
+    cb.place(7, 0, new Rook(BLACK, false, cb.b));   // a8
+    cb.place(7, 7, new Rook(BLACK, true, cb.b));     // h8
+    cb.b.setCastlingRight(false, true, true);   // black kingside
+    cb.b.setCastlingRight(false, false, true);  // black queenside
+    cb.activate();
+
+    // Verify black has both castling rights initially
+    REQUIRE(cb.b.getCastlingRight(false, true));   // black kingside
+    REQUIRE(cb.b.getCastlingRight(false, false));  // black queenside
+
+    // White rook captures black rook on a8 (row 7, col 0)
+    REQUIRE(cb.game.makeMove(ChessMove(0, 0, 7, 0)));
+
+    // Black queenside castling right should be gone
+    REQUIRE(!cb.b.getCastlingRight(false, false));
+    // Black kingside should still be available
+    REQUIRE(cb.b.getCastlingRight(false, true));
+}
+
+TEST_CASE("ChessGame: FEN reflects castling right lost on rook capture",
+          "[ChessGame][Castling][FEN]") {
+    // Position from SPEC.md test vector 9.4.2:
+    // r3k2r/8/8/8/8/8/8/R3K3 w Qkq - 0 1
+    // White plays Rxa8+ — captures Black's queenside rook.
+    // Expected FEN after: R3k2r/8/8/8/8/8/8/4K3 b k - 0 1
+    auto game = ChessGame::fromFen("r3k2r/8/8/8/8/8/8/R3K3 w Qkq - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->makeMove(ChessMove(0, 0, 7, 0)));  // Rxa8
+    REQUIRE(game->toFen() == "R3k2r/8/8/8/8/8/8/4K3 b k - 0 1");
+}
+
+TEST_CASE("ChessGame: king move clears both castling rights via flags",
+          "[ChessGame][Castling]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));
+    cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, true, true);
+    cb.b.setCastlingRight(true, false, true);
+    cb.activate();
+
+    REQUIRE(cb.b.getCastlingRight(true, true));
+    REQUIRE(cb.b.getCastlingRight(true, false));
+
+    // Move white king
+    REQUIRE(cb.game.makeMove(ChessMove(0, 4, 0, 5)));
+
+    REQUIRE(!cb.b.getCastlingRight(true, true));
+    REQUIRE(!cb.b.getCastlingRight(true, false));
+}
+
+TEST_CASE("ChessGame: rook move from starting square clears that side's right",
+          "[ChessGame][Castling]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));
+    cb.place(0, 7, new Rook(WHITE, true, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.b.setCastlingRight(true, true, true);
+    cb.b.setCastlingRight(true, false, true);
+    cb.activate();
+
+    // Move kingside rook
+    REQUIRE(cb.game.makeMove(ChessMove(0, 7, 1, 7)));
+
+    REQUIRE(!cb.b.getCastlingRight(true, true));   // kingside gone
+    REQUIRE(cb.b.getCastlingRight(true, false));    // queenside still there
+}
+
+TEST_CASE("ChessGame::fromFen: castling rights set from FEN flags, not piece state",
+          "[ChessGame][Castling][FEN]") {
+    // FEN says only white queenside (Q) — rooks may or may not be in starting positions.
+    auto game = ChessGame::fromFen("r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w Q - 0 1");
+    REQUIRE(game != nullptr);
+    ChessBoard& b = game->getPieceBoard();
+    REQUIRE(!b.getCastlingRight(true, true));   // white kingside: no
+    REQUIRE(b.getCastlingRight(true, false));    // white queenside: yes
+    REQUIRE(!b.getCastlingRight(false, true));   // black kingside: no
+    REQUIRE(!b.getCastlingRight(false, false));  // black queenside: no
+    // Round-trip FEN
+    REQUIRE(game->toFen() == "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w Q - 0 1");
+}
+
+TEST_CASE("ChessGame::fromFen: no castling rights preserved as flags",
+          "[ChessGame][Castling][FEN]") {
+    std::string fen = "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w - - 0 1";
+    auto game = ChessGame::fromFen(fen);
+    REQUIRE(game != nullptr);
+    ChessBoard& b = game->getPieceBoard();
+    REQUIRE(!b.getCastlingRight(true, true));
+    REQUIRE(!b.getCastlingRight(true, false));
+    REQUIRE(!b.getCastlingRight(false, true));
+    REQUIRE(!b.getCastlingRight(false, false));
+    REQUIRE(game->toFen() == fen);
 }


### PR DESCRIPTION
## Summary
- Fixes divergence #4: position identity for threefold repetition now correctly ignores en passant target squares when no legal ep capture exists (SPEC 4.3)
- `positionKey()` checks whether any adjacent enemy pawn can legally execute the ep capture (via `canMove`, which handles pins) before including the ep field
- If no legal capture exists, the ep field is replaced with `"-"` in the position key

## Dependencies
- Depends on PR #24 (castling rights, step 8a) — merge that first

## Test plan
- [x] New test: position with irrelevant ep target (pawn on a4, ep=a3, no black pawn to capture) — king cycling creates threefold repetition correctly detected
- [x] All 131 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)