### PR TITLE
chess: insufficient material detection (step 8c)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1606,6 +1606,55 @@ bool ChessGame::isAutomaticDraw() const {
     return halfmoveClock >= 150 || positionCount() >= 5;
 }
 
+bool ChessGame::insufficientMaterial() const {
+    // SPEC 4.4: Exactly these material combinations are insufficient:
+    // 1. K vs K
+    // 2. K+B vs K
+    // 3. K+N vs K
+    // 4. K+B vs K+B (same color square bishops)
+
+    int whiteBishops = 0, blackBishops = 0;
+    int whiteKnights = 0, blackKnights = 0;
+    int whiteOther = 0, blackOther = 0;  // pawns, rooks, queens
+    int whiteBishopColor = -1, blackBishopColor = -1;  // 0=dark, 1=light
+
+    for (int x = 0; x < 8; x++) {
+        for (int y = 0; y < 8; y++) {
+            const ChessPiece* p = board.getPiece(x, y);
+            if (p == nullptr) continue;
+            PieceType t = p->getType();
+            if (t == KING) continue;
+            bool w = p->getWhite();
+            if (t == BISHOP) {
+                if (w) { whiteBishops++; whiteBishopColor = (x + y) % 2; }
+                else   { blackBishops++; blackBishopColor = (x + y) % 2; }
+            } else if (t == KNIGHT) {
+                if (w) whiteKnights++; else blackKnights++;
+            } else {
+                if (w) whiteOther++; else blackOther++;
+            }
+        }
+    }
+
+    // Any pawns, rooks, or queens → sufficient
+    if (whiteOther > 0 || blackOther > 0) return false;
+
+    int wMinor = whiteBishops + whiteKnights;
+    int bMinor = blackBishops + blackKnights;
+
+    // K vs K
+    if (wMinor == 0 && bMinor == 0) return true;
+    // K+B vs K or K+N vs K (either side)
+    if (wMinor == 1 && bMinor == 0) return true;
+    if (wMinor == 0 && bMinor == 1) return true;
+    // K+B vs K+B same color
+    if (whiteBishops == 1 && blackBishops == 1 &&
+        whiteKnights == 0 && blackKnights == 0 &&
+        whiteBishopColor == blackBishopColor) return true;
+
+    return false;
+}
+
 std::string ChessGame::toJson() const {
     std::string json = "{";
 

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -339,6 +339,7 @@ class ChessGame {
 
     bool canClaimDraw() const;
     bool isAutomaticDraw() const;
+    bool insufficientMaterial() const;
 
     /** Returns a JSON string representing the full game state. */
     std::string toJson() const;

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1463,6 +1463,78 @@ TEST_CASE("ChessGame: position identity ignores ep square when no legal capture 
 }
 
 // ============================================================================
+// Insufficient Material (SPEC 4.4)
+// ============================================================================
+
+TEST_CASE("ChessGame: K vs K is insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+B vs K is insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KB2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K vs K+B is insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4kb2/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+N vs K is insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KN2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+B vs K+B same color bishops is insufficient material", "[ChessGame][Draw]") {
+    // Both bishops on light squares (f1=light, c8=light: f1 is (0,5) -> 0+5=5 odd=light,
+    // c8 is (7,2) -> 7+2=9 odd=light)
+    auto game = ChessGame::fromFen("2b1k3/8/8/8/8/8/8/4KB2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+B vs K+B opposite color bishops is NOT insufficient", "[ChessGame][Draw]") {
+    // White bishop on f1 (light), black bishop on b8 (dark: (7,1) -> 7+1=8 even=dark)
+    auto game = ChessGame::fromFen("1b2k3/8/8/8/8/8/8/4KB2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+N+N vs K is NOT insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3NKN2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+R vs K is NOT insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KR2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+Q vs K is NOT insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KQ2 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: K+P vs K is NOT insufficient material", "[ChessGame][Draw]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->insufficientMaterial());
+}
+
+TEST_CASE("ChessGame: initial position is NOT insufficient material", "[ChessGame][Draw]") {
+    ChessGame game;
+    REQUIRE_FALSE(game.insufficientMaterial());
+}
+
+// ============================================================================
 // JSON Board State (toJson)
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `insufficientMaterial()` to `ChessGame` per SPEC 4.4
- Detects exactly: K vs K, K+B vs K, K+N vs K, K+B vs K+B (same-color bishops)
- Advisory status only (queryable, not game-ending)
- Single board scan counting minor pieces and tracking bishop square colors

## Dependencies
- Depends on PR #25 (position identity, step 8b) and PR #24 (castling rights, step 8a)

## Test plan
- [x] 11 new tests: all specified insufficient cases + negative cases (opposite-color bishops, K+N+N, K+R, K+Q, K+P, initial position)
- [x] All 142 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)