### PR TITLE
chess: FEN deserialization validation (step 8d)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1421,14 +1421,126 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
 }
 
 std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
-    std::istringstream ss(fen);
-    std::string placement, activeColor, castling, enPassant;
-    int halfmove = 0, fullmove = 1;
-    ss >> placement >> activeColor >> castling >> enPassant >> halfmove >> fullmove;
+    // Split into exactly 6 space-separated fields.
+    std::vector<std::string> fields;
+    {
+        std::istringstream ss(fen);
+        std::string token;
+        while (ss >> token) fields.push_back(token);
+    }
+    if (fields.size() != 6) return nullptr;
 
-    if (ss.fail()) {
+    const std::string& placement = fields[0];
+    const std::string& activeColor = fields[1];
+    const std::string& castling = fields[2];
+    const std::string& enPassant = fields[3];
+
+    // Validate halfmove clock and fullmove number (must be non-negative integers).
+    int halfmove, fullmove;
+    try {
+        size_t pos;
+        halfmove = std::stoi(fields[4], &pos);
+        if (pos != fields[4].size()) return nullptr;  // trailing chars
+        fullmove = std::stoi(fields[5], &pos);
+        if (pos != fields[5].size()) return nullptr;
+    } catch (...) {
         return nullptr;
     }
+    if (halfmove < 0) return nullptr;
+    if (fullmove < 1) return nullptr;
+
+    // Validate active color.
+    if (activeColor != "w" && activeColor != "b") return nullptr;
+
+    // Validate castling field: must be "-" or a subset of "KQkq" in order.
+    if (castling != "-") {
+        const std::string allowed = "KQkq";
+        size_t prev = 0;
+        for (char c : castling) {
+            size_t idx = allowed.find(c);
+            if (idx == std::string::npos) return nullptr;
+            if (idx < prev) return nullptr;  // wrong order
+            prev = idx + 1;
+        }
+    }
+
+    // Validate en passant field.
+    if (enPassant != "-") {
+        if (enPassant.size() != 2) return nullptr;
+        if (enPassant[0] < 'a' || enPassant[0] > 'h') return nullptr;
+        if (enPassant[1] < '1' || enPassant[1] > '8') return nullptr;
+        // ep target must be on rank 3 or 6
+        if (enPassant[1] != '3' && enPassant[1] != '6') return nullptr;
+    }
+
+    // Validate and parse piece placement.
+    // Split by '/' — must have exactly 8 ranks.
+    std::vector<std::string> ranks;
+    {
+        std::string rank;
+        for (char c : placement) {
+            if (c == '/') {
+                ranks.push_back(rank);
+                rank.clear();
+            } else {
+                rank += c;
+            }
+        }
+        ranks.push_back(rank);
+    }
+    if (ranks.size() != 8) return nullptr;
+
+    // Validate each rank: no consecutive digits, exactly 8 squares, valid piece chars.
+    // Also count kings and check for pawns on back ranks.
+    int whiteKings = 0, blackKings = 0;
+    int whiteKingX = -1, whiteKingY = -1, blackKingX = -1, blackKingY = -1;
+
+    // Build a piece map: ranks[0] = rank 8 (x=7), ranks[7] = rank 1 (x=0).
+    struct PlacedPiece { int x; int y; char letter; bool isWhite; };
+    std::vector<PlacedPiece> pieces;
+
+    for (int ri = 0; ri < 8; ri++) {
+        int boardX = 7 - ri;  // rank 8 → x=7, rank 1 → x=0
+        int squares = 0;
+        bool lastWasDigit = false;
+        for (char c : ranks[ri]) {
+            if (c >= '1' && c <= '8') {
+                if (lastWasDigit) return nullptr;  // consecutive digits
+                squares += (c - '0');
+                lastWasDigit = true;
+            } else {
+                lastWasDigit = false;
+                bool isWhite = (c >= 'A' && c <= 'Z');
+                char lower = isWhite ? static_cast<char>(c + 32) : c;
+                if (lower != 'p' && lower != 'r' && lower != 'n' &&
+                    lower != 'b' && lower != 'q' && lower != 'k')
+                    return nullptr;  // invalid piece letter
+
+                // Pawn on back rank check
+                if (lower == 'p' && (boardX == 0 || boardX == 7))
+                    return nullptr;
+
+                // Count kings
+                if (lower == 'k') {
+                    if (isWhite) { whiteKings++; whiteKingX = boardX; whiteKingY = squares; }
+                    else         { blackKings++; blackKingX = boardX; blackKingY = squares; }
+                }
+
+                pieces.push_back({boardX, squares, lower, isWhite});
+                squares++;
+            }
+        }
+        if (squares != 8) return nullptr;  // rank doesn't have exactly 8 squares
+    }
+
+    // Exactly one king per side.
+    if (whiteKings != 1 || blackKings != 1) return nullptr;
+
+    // Kings must not be adjacent.
+    if (std::abs(whiteKingX - blackKingX) <= 1 && std::abs(whiteKingY - blackKingY) <= 1)
+        return nullptr;
+
+    // --- All validation passed; build the game. ---
 
     auto game = std::unique_ptr<ChessGame>(new ChessGame());
     game->setRules(false);
@@ -1438,55 +1550,26 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
         for (int ry = 0; ry < 8; ry++)
             game->setPiece(rx, ry, nullptr);
 
-    // 1. Parse piece placement (rank 8 = x=7 down to rank 1 = x=0)
-    int x = 7;
-    int y = 0;
-    for (char c : placement) {
-        if (c == '/') {
-            x--;
-            y = 0;
-        } else if (c >= '1' && c <= '8') {
-            y += (c - '0');
-        } else {
-            bool isWhite = (c >= 'A' && c <= 'Z');
-            char lower = isWhite ? static_cast<char>(c + 32) : c;
-            bool isKingSide = (y > 3);
-            // Pawn index based on column, matching ChessBoard constructor convention
-            int pawnIdx = isKingSide ? (y - 3) : (4 - y);
-
-            std::unique_ptr<ChessPiece> piece;
-            switch (lower) {
-                case 'p':
-                    piece = std::make_unique<Pawn>(isWhite, isKingSide, game->board, pawnIdx);
-                    break;
-                case 'r':
-                    piece = std::make_unique<Rook>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'n':
-                    piece = std::make_unique<Knight>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'b':
-                    piece = std::make_unique<Bishop>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'q':
-                    piece = std::make_unique<Queen>(isWhite, game->board, 0, isKingSide);
-                    break;
-                case 'k':
-                    piece = std::make_unique<King>(isWhite, game->board);
-                    break;
-                default:
-                    return nullptr;  // invalid piece character
-            }
-            game->board.place(x, y, std::move(piece));
-            y++;
+    // Place pieces.
+    for (const auto& pp : pieces) {
+        bool isKingSide = (pp.y > 3);
+        int pawnIdx = isKingSide ? (pp.y - 3) : (4 - pp.y);
+        std::unique_ptr<ChessPiece> piece;
+        switch (pp.letter) {
+            case 'p': piece = std::make_unique<Pawn>(pp.isWhite, isKingSide, game->board, pawnIdx); break;
+            case 'r': piece = std::make_unique<Rook>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'n': piece = std::make_unique<Knight>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'b': piece = std::make_unique<Bishop>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'q': piece = std::make_unique<Queen>(pp.isWhite, game->board, 0, isKingSide); break;
+            case 'k': piece = std::make_unique<King>(pp.isWhite, game->board); break;
         }
+        game->board.place(pp.x, pp.y, std::move(piece));
     }
 
-    // 2. Active color
+    // Active color.
     game->whiteTurn = (activeColor == "w");
 
-    // 3. Castling rights — set independent flags on ChessBoard.
-    //    Default is all true; clear the ones not present in the FEN string.
+    // Castling rights — default is all true; clear the ones not present.
     if (castling.find('K') == std::string::npos)
         game->board.clearCastlingRight(true, true);
     if (castling.find('Q') == std::string::npos)
@@ -1496,33 +1579,32 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     if (castling.find('q') == std::string::npos)
         game->board.clearCastlingRight(false, false);
 
-    // 4. En passant target square
+    // En passant target square.
     if (enPassant != "-") {
-        int epY = enPassant[0] - 'a';  // file
-        int epX = enPassant[1] - '1';  // rank (0-indexed)
-        // The pawn that double-pushed is one rank past the target:
-        // If it's black's turn (activeColor == "b"), white just pushed, pawn at epX+1.
-        // If it's white's turn (activeColor == "w"), black just pushed, pawn at epX-1.
+        int epY = enPassant[0] - 'a';
+        int epX = enPassant[1] - '1';
         int pawnX = (activeColor == "b") ? (epX + 1) : (epX - 1);
         ChessPiece* p = game->board.getMoveablePiece(pawnX, epY);
         if (p != nullptr && p->getType() == PAWN)
             dynamic_cast<Pawn*>(p)->setEnPassant(true);
     }
 
-    // 5. Halfmove clock
+    // Halfmove clock.
     game->halfmoveClock = halfmove;
 
-    // 6. Fullmove number — derive history size so toFen() reproduces it.
-    //    toFen() computes: 1 + history.size() / 2
-    //    So: history.size() = (fullmove - 1) * 2 + (black to move ? 1 : 0)
+    // Fullmove number — derive history size so toFen() reproduces it.
     int histSize = (fullmove - 1) * 2 + (activeColor == "b" ? 1 : 0);
     game->history.clear();
     for (int i = 0; i < histSize; i++)
         game->history.push_back(ChessMove());
 
-    // 7. Initialize position history with the current position
-    game->positionHistory.clear();
+    // Side not to move must not be in check.
     game->setRules(true);
+    bool notToMove = !game->whiteTurn;
+    if (game->board.checkCheck(notToMove)) return nullptr;
+
+    // Initialize position history with the current position.
+    game->positionHistory.clear();
     game->positionHistory.push_back(game->positionKey());
 
     return game;

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1715,6 +1715,117 @@ TEST_CASE("ChessGame::fromFen: legal moves from loaded position work", "[ChessGa
 }
 
 // ============================================================================
+// FEN Validation (SPEC 5.3)
+// ============================================================================
+
+// --- Syntactic validation (must reject) ---
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of fields (5 fields)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of fields (7 fields)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 extra");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of ranks (7 ranks)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects rank with too many squares", "[ChessGame][FEN]") {
+    // Rank 1 has 9 squares: RNBQKBNRR
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects rank with too few squares", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBN w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects consecutive digits in rank", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/44/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid piece letter", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNXQKBNR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid active color", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid castling characters", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQxq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid en passant square", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq z9 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects negative halfmove clock", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - -1 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects fullmove number less than 1", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 0");
+    REQUIRE(game == nullptr);
+}
+
+// --- Position validation (should reject) ---
+
+TEST_CASE("ChessGame::fromFen: rejects missing white king", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/8 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects missing black king", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("8/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects two white kings", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KK3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects pawn on rank 1", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/P3K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects pawn on rank 8", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("p3k3/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects side not to move in check", "[ChessGame][FEN]") {
+    // White to move, black king on e8 is attacked by white rook on e1 → invalid
+    // (side not to move = black is in check)
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KR2 w - - 0 1");
+    // Wait — rook on f1 doesn't attack e8. Use rook on e-file instead.
+    // "4k3/8/8/8/8/8/8/R3K3 w - - 0 1" — rook on a1 doesn't check e8.
+    // Need: white rook on e-file with no pieces between it and the black king on e8.
+    // "4k3/8/8/8/8/8/8/3KR3" — rook on e1, king on d1, black king e8 → rook checks e8!
+    game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects adjacent kings", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("8/8/8/8/8/8/8/3Kk3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+// ============================================================================
 // Independent castling rights
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Rewrites `fromFen()` with comprehensive validation per SPEC 5.3
- Syntactic validation: field count, rank count, square counts, consecutive digits, piece letters, active color, castling chars, en passant format, halfmove/fullmove ranges
- Position validation: king count (exactly 1 per side), no pawns on back ranks, no adjacent kings, side not to move not in check

## Dependencies
- Depends on PR #26 (step 8c), #25 (step 8b), #24 (step 8a)

## Test plan
- [x] 19 new tests covering all syntactic and position validation cases
- [x] All 161 tests pass (existing FEN tests use valid strings, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)