### PR TITLE
chess: SAN normalization function (step 8g)

### DIFF
--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1519,6 +1519,74 @@ std::string ChessGame::toSan(const ChessMove& move) const {
     return san;
 }
 
+std::string ChessGame::normalizeSan(const std::string& san) {
+    std::string s = san;
+
+    // 0. Strip leading/trailing whitespace first so other steps work on clean input.
+    {
+        size_t start = s.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) return "";
+        size_t end = s.find_last_not_of(" \t\n\r");
+        s = s.substr(start, end - start + 1);
+    }
+
+    // 1. Strip NAGs: '$' followed by digits.
+    {
+        std::string result;
+        for (size_t i = 0; i < s.size(); i++) {
+            if (s[i] == '$') {
+                // Skip $ and following digits.
+                i++;
+                while (i < s.size() && s[i] >= '0' && s[i] <= '9') i++;
+                i--;  // loop increment
+            } else {
+                result += s[i];
+            }
+        }
+        s = result;
+    }
+
+    // 2. Strip move assessment glyphs (longest first): !!, ??, !?, ?!, !, ?
+    {
+        // Strip from the end, after any check/checkmate suffix.
+        // First, save and strip check/checkmate suffixes.
+        std::string suffix;
+        while (!s.empty() && (s.back() == '+' || s.back() == '#')) {
+            suffix = s.back() + suffix;
+            s.pop_back();
+        }
+        // Now strip assessment glyphs from the end.
+        bool changed = true;
+        while (changed && !s.empty()) {
+            changed = false;
+            for (const char* glyph : {"!!", "??", "!?", "?!", "!", "?"}) {
+                size_t glen = strlen(glyph);
+                if (s.size() >= glen && s.substr(s.size() - glen) == glyph) {
+                    s.resize(s.size() - glen);
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        s += suffix;
+    }
+
+    // 3. Convert digit-zero castling to letter-O.
+    if (s == "0-0" || s == "0-0+" || s == "0-0#") {
+        s = "O-O" + s.substr(3);
+    } else if (s == "0-0-0" || s == "0-0-0+" || s == "0-0-0#") {
+        s = "O-O-O" + s.substr(5);
+    }
+
+    // 4. Strip leading/trailing whitespace.
+    size_t start = s.find_first_not_of(" \t\n\r");
+    if (start == std::string::npos) return "";
+    size_t end = s.find_last_not_of(" \t\n\r");
+    s = s.substr(start, end - start + 1);
+
+    return s;
+}
+
 std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     // Split into exactly 6 space-separated fields.
     std::vector<std::string> fields;

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1420,6 +1420,94 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
     return match;
 }
 
+std::string ChessGame::toSan(const ChessMove& move) const {
+    if (move.isEnd()) return "";
+
+    int sx = move.getStartX(), sy = move.getStartY();
+    int ex = move.getEndX(),   ey = move.getEndY();
+    const ChessPiece* piece = board.getPiece(sx, sy);
+    if (piece == nullptr) return "";
+
+    PieceType type = piece->getType();
+    bool isWhite = piece->getWhite();
+
+    std::string san;
+
+    // Castling.
+    if (type == KING && std::abs(sy - ey) == 2) {
+        san = (ey > sy) ? "O-O" : "O-O-O";
+    } else {
+        // Piece letter prefix (not for pawns).
+        const char pieceLetters[] = {'?', 'R', 'N', 'B', 'K', 'Q'};
+        if (type != PAWN) {
+            san += pieceLetters[type];
+
+            // Disambiguation: find all same-type, same-color pieces that can
+            // geometrically reach the destination (canMove with chkchk=false).
+            bool needFile = false, needRank = false;
+            bool sameFile = false, sameRank = false;
+            int ambigCount = 0;
+            for (int x = 0; x < 8; x++) {
+                for (int y = 0; y < 8; y++) {
+                    if (x == sx && y == sy) continue;
+                    const ChessPiece* other = board.getPiece(x, y);
+                    if (other == nullptr) continue;
+                    if (other->getType() != type || other->getWhite() != isWhite) continue;
+                    if (!other->canMove(ex, ey, false)) continue;
+                    ambigCount++;
+                    if (y == sy) sameFile = true;
+                    if (x == sx) sameRank = true;
+                }
+            }
+            if (ambigCount > 0) {
+                if (!sameFile) {
+                    needFile = true;
+                } else if (!sameRank) {
+                    needRank = true;
+                } else {
+                    needFile = true;
+                    needRank = true;
+                }
+            }
+            if (needFile) san += static_cast<char>('a' + sy);
+            if (needRank) san += static_cast<char>('1' + sx);
+        }
+
+        // Capture indicator.
+        bool isCapture = (board.getPiece(ex, ey) != nullptr);
+        // En passant: pawn moves diagonally to empty square.
+        if (type == PAWN && sy != ey && !isCapture) isCapture = true;
+        if (isCapture) {
+            if (type == PAWN) san += static_cast<char>('a' + sy);  // pawn source file
+            san += 'x';
+        }
+
+        // Destination square.
+        san += static_cast<char>('a' + ey);
+        san += static_cast<char>('1' + ex);
+
+        // Promotion.
+        if (move.getPromotion() != PAWN) {
+            san += '=';
+            san += pieceLetters[move.getPromotion()];
+        }
+    }
+
+    // Check/checkmate suffix: simulate the move to test.
+    // Make a copy via FEN round-trip to avoid mutating this game.
+    auto copy = ChessGame::fromFen(toFen());
+    if (copy && copy->makeMove(ChessMove(sx, sy, ex, ey, move.getPromotion()))) {
+        bool opponentColor = !isWhite;
+        if (copy->checkmate(opponentColor)) {
+            san += '#';
+        } else if (copy->board.checkCheck(opponentColor)) {
+            san += '+';
+        }
+    }
+
+    return san;
+}
+
 std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     // Split into exactly 6 space-separated fields.
     std::vector<std::string> fields;

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1421,14 +1421,126 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
 }
 
 std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
-    std::istringstream ss(fen);
-    std::string placement, activeColor, castling, enPassant;
-    int halfmove = 0, fullmove = 1;
-    ss >> placement >> activeColor >> castling >> enPassant >> halfmove >> fullmove;
+    // Split into exactly 6 space-separated fields.
+    std::vector<std::string> fields;
+    {
+        std::istringstream ss(fen);
+        std::string token;
+        while (ss >> token) fields.push_back(token);
+    }
+    if (fields.size() != 6) return nullptr;
 
-    if (ss.fail()) {
+    const std::string& placement = fields[0];
+    const std::string& activeColor = fields[1];
+    const std::string& castling = fields[2];
+    const std::string& enPassant = fields[3];
+
+    // Validate halfmove clock and fullmove number (must be non-negative integers).
+    int halfmove, fullmove;
+    try {
+        size_t pos;
+        halfmove = std::stoi(fields[4], &pos);
+        if (pos != fields[4].size()) return nullptr;  // trailing chars
+        fullmove = std::stoi(fields[5], &pos);
+        if (pos != fields[5].size()) return nullptr;
+    } catch (...) {
         return nullptr;
     }
+    if (halfmove < 0) return nullptr;
+    if (fullmove < 1) return nullptr;
+
+    // Validate active color.
+    if (activeColor != "w" && activeColor != "b") return nullptr;
+
+    // Validate castling field: must be "-" or a subset of "KQkq" in order.
+    if (castling != "-") {
+        const std::string allowed = "KQkq";
+        size_t prev = 0;
+        for (char c : castling) {
+            size_t idx = allowed.find(c);
+            if (idx == std::string::npos) return nullptr;
+            if (idx < prev) return nullptr;  // wrong order
+            prev = idx + 1;
+        }
+    }
+
+    // Validate en passant field.
+    if (enPassant != "-") {
+        if (enPassant.size() != 2) return nullptr;
+        if (enPassant[0] < 'a' || enPassant[0] > 'h') return nullptr;
+        if (enPassant[1] < '1' || enPassant[1] > '8') return nullptr;
+        // ep target must be on rank 3 or 6
+        if (enPassant[1] != '3' && enPassant[1] != '6') return nullptr;
+    }
+
+    // Validate and parse piece placement.
+    // Split by '/' — must have exactly 8 ranks.
+    std::vector<std::string> ranks;
+    {
+        std::string rank;
+        for (char c : placement) {
+            if (c == '/') {
+                ranks.push_back(rank);
+                rank.clear();
+            } else {
+                rank += c;
+            }
+        }
+        ranks.push_back(rank);
+    }
+    if (ranks.size() != 8) return nullptr;
+
+    // Validate each rank: no consecutive digits, exactly 8 squares, valid piece chars.
+    // Also count kings and check for pawns on back ranks.
+    int whiteKings = 0, blackKings = 0;
+    int whiteKingX = -1, whiteKingY = -1, blackKingX = -1, blackKingY = -1;
+
+    // Build a piece map: ranks[0] = rank 8 (x=7), ranks[7] = rank 1 (x=0).
+    struct PlacedPiece { int x; int y; char letter; bool isWhite; };
+    std::vector<PlacedPiece> pieces;
+
+    for (int ri = 0; ri < 8; ri++) {
+        int boardX = 7 - ri;  // rank 8 → x=7, rank 1 → x=0
+        int squares = 0;
+        bool lastWasDigit = false;
+        for (char c : ranks[ri]) {
+            if (c >= '1' && c <= '8') {
+                if (lastWasDigit) return nullptr;  // consecutive digits
+                squares += (c - '0');
+                lastWasDigit = true;
+            } else {
+                lastWasDigit = false;
+                bool isWhite = (c >= 'A' && c <= 'Z');
+                char lower = isWhite ? static_cast<char>(c + 32) : c;
+                if (lower != 'p' && lower != 'r' && lower != 'n' &&
+                    lower != 'b' && lower != 'q' && lower != 'k')
+                    return nullptr;  // invalid piece letter
+
+                // Pawn on back rank check
+                if (lower == 'p' && (boardX == 0 || boardX == 7))
+                    return nullptr;
+
+                // Count kings
+                if (lower == 'k') {
+                    if (isWhite) { whiteKings++; whiteKingX = boardX; whiteKingY = squares; }
+                    else         { blackKings++; blackKingX = boardX; blackKingY = squares; }
+                }
+
+                pieces.push_back({boardX, squares, lower, isWhite});
+                squares++;
+            }
+        }
+        if (squares != 8) return nullptr;  // rank doesn't have exactly 8 squares
+    }
+
+    // Exactly one king per side.
+    if (whiteKings != 1 || blackKings != 1) return nullptr;
+
+    // Kings must not be adjacent.
+    if (std::abs(whiteKingX - blackKingX) <= 1 && std::abs(whiteKingY - blackKingY) <= 1)
+        return nullptr;
+
+    // --- All validation passed; build the game. ---
 
     auto game = std::unique_ptr<ChessGame>(new ChessGame());
     game->setRules(false);
@@ -1438,55 +1550,26 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
         for (int ry = 0; ry < 8; ry++)
             game->setPiece(rx, ry, nullptr);
 
-    // 1. Parse piece placement (rank 8 = x=7 down to rank 1 = x=0)
-    int x = 7;
-    int y = 0;
-    for (char c : placement) {
-        if (c == '/') {
-            x--;
-            y = 0;
-        } else if (c >= '1' && c <= '8') {
-            y += (c - '0');
-        } else {
-            bool isWhite = (c >= 'A' && c <= 'Z');
-            char lower = isWhite ? static_cast<char>(c + 32) : c;
-            bool isKingSide = (y > 3);
-            // Pawn index based on column, matching ChessBoard constructor convention
-            int pawnIdx = isKingSide ? (y - 3) : (4 - y);
-
-            std::unique_ptr<ChessPiece> piece;
-            switch (lower) {
-                case 'p':
-                    piece = std::make_unique<Pawn>(isWhite, isKingSide, game->board, pawnIdx);
-                    break;
-                case 'r':
-                    piece = std::make_unique<Rook>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'n':
-                    piece = std::make_unique<Knight>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'b':
-                    piece = std::make_unique<Bishop>(isWhite, isKingSide, game->board, 0);
-                    break;
-                case 'q':
-                    piece = std::make_unique<Queen>(isWhite, game->board, 0, isKingSide);
-                    break;
-                case 'k':
-                    piece = std::make_unique<King>(isWhite, game->board);
-                    break;
-                default:
-                    return nullptr;  // invalid piece character
-            }
-            game->board.place(x, y, std::move(piece));
-            y++;
+    // Place pieces.
+    for (const auto& pp : pieces) {
+        bool isKingSide = (pp.y > 3);
+        int pawnIdx = isKingSide ? (pp.y - 3) : (4 - pp.y);
+        std::unique_ptr<ChessPiece> piece;
+        switch (pp.letter) {
+            case 'p': piece = std::make_unique<Pawn>(pp.isWhite, isKingSide, game->board, pawnIdx); break;
+            case 'r': piece = std::make_unique<Rook>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'n': piece = std::make_unique<Knight>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'b': piece = std::make_unique<Bishop>(pp.isWhite, isKingSide, game->board, 0); break;
+            case 'q': piece = std::make_unique<Queen>(pp.isWhite, game->board, 0, isKingSide); break;
+            case 'k': piece = std::make_unique<King>(pp.isWhite, game->board); break;
         }
+        game->board.place(pp.x, pp.y, std::move(piece));
     }
 
-    // 2. Active color
+    // Active color.
     game->whiteTurn = (activeColor == "w");
 
-    // 3. Castling rights — set independent flags on ChessBoard.
-    //    Default is all true; clear the ones not present in the FEN string.
+    // Castling rights — default is all true; clear the ones not present.
     if (castling.find('K') == std::string::npos)
         game->board.clearCastlingRight(true, true);
     if (castling.find('Q') == std::string::npos)
@@ -1496,33 +1579,32 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     if (castling.find('q') == std::string::npos)
         game->board.clearCastlingRight(false, false);
 
-    // 4. En passant target square
+    // En passant target square.
     if (enPassant != "-") {
-        int epY = enPassant[0] - 'a';  // file
-        int epX = enPassant[1] - '1';  // rank (0-indexed)
-        // The pawn that double-pushed is one rank past the target:
-        // If it's black's turn (activeColor == "b"), white just pushed, pawn at epX+1.
-        // If it's white's turn (activeColor == "w"), black just pushed, pawn at epX-1.
+        int epY = enPassant[0] - 'a';
+        int epX = enPassant[1] - '1';
         int pawnX = (activeColor == "b") ? (epX + 1) : (epX - 1);
         ChessPiece* p = game->board.getMoveablePiece(pawnX, epY);
         if (p != nullptr && p->getType() == PAWN)
             dynamic_cast<Pawn*>(p)->setEnPassant(true);
     }
 
-    // 5. Halfmove clock
+    // Halfmove clock.
     game->halfmoveClock = halfmove;
 
-    // 6. Fullmove number — derive history size so toFen() reproduces it.
-    //    toFen() computes: 1 + history.size() / 2
-    //    So: history.size() = (fullmove - 1) * 2 + (black to move ? 1 : 0)
+    // Fullmove number — derive history size so toFen() reproduces it.
     int histSize = (fullmove - 1) * 2 + (activeColor == "b" ? 1 : 0);
     game->history.clear();
     for (int i = 0; i < histSize; i++)
         game->history.push_back(ChessMove());
 
-    // 7. Initialize position history with the current position
-    game->positionHistory.clear();
+    // Side not to move must not be in check.
     game->setRules(true);
+    bool notToMove = !game->whiteTurn;
+    if (game->board.checkCheck(notToMove)) return nullptr;
+
+    // Initialize position history with the current position.
+    game->positionHistory.clear();
     game->positionHistory.push_back(game->positionKey());
 
     return game;

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1292,27 +1292,42 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
     }
     if (s.empty()) return ChessMove();
 
+    // Helper: validate check/checkmate suffix against the actual move result.
+    auto validateSuffix = [&](const ChessMove& m) -> ChessMove {
+        if (!hasCheck && !hasCheckmate) return m;
+        auto copy = ChessGame::fromFen(toFen());
+        if (!copy) return ChessMove();
+        if (!copy->makeMove(ChessMove(m.getStartX(), m.getStartY(),
+                                       m.getEndX(), m.getEndY(), m.getPromotion())))
+            return ChessMove();
+        bool opponent = !whiteTurn;  // the side being checked is the one not moving
+        bool givesCheck = copy->board.checkCheck(opponent);
+        bool givesCheckmate = copy->checkmate(opponent);
+        if (hasCheckmate && !givesCheckmate) return ChessMove();
+        if (hasCheck && !givesCheck) return ChessMove();
+        return m;
+    };
+
     // Castling.
-    if (s == "O-O" || s == "0-0") {
+    if (s == "O-O") {
         int rank = whiteTurn ? 0 : 7;
         ChessMove cm(rank, 4, rank, 6);
-        // Verify it's legal.
         auto moves = getMoves(whiteTurn);
         for (const auto& m : moves) {
             if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
                 m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
-                return m;
+                return validateSuffix(m);
         }
         return ChessMove();
     }
-    if (s == "O-O-O" || s == "0-0-0") {
+    if (s == "O-O-O") {
         int rank = whiteTurn ? 0 : 7;
         ChessMove cm(rank, 4, rank, 2);
         auto moves = getMoves(whiteTurn);
         for (const auto& m : moves) {
             if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
                 m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
-                return m;
+                return validateSuffix(m);
         }
         return ChessMove();
     }
@@ -1324,10 +1339,10 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         if (eq != std::string::npos && eq + 1 < s.size()) {
             char pc = s[eq + 1];
             switch (pc) {
-                case 'Q': case 'q': promo = QUEEN; break;
-                case 'R': case 'r': promo = ROOK; break;
-                case 'B': case 'b': promo = BISHOP; break;
-                case 'N': case 'n': promo = KNIGHT; break;
+                case 'Q': promo = QUEEN; break;
+                case 'R': promo = ROOK; break;
+                case 'B': promo = BISHOP; break;
+                case 'N': promo = KNIGHT; break;
                 default: return ChessMove();
             }
             s = s.substr(0, eq);
@@ -1413,11 +1428,7 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         if (!isCapture) return ChessMove();
     }
 
-    // Note: check (+) and checkmate (#) annotations are accepted but not
-    // validated, as verification would require simulating the move. These
-    // are informational annotations per SAN convention.
-
-    return match;
+    return validateSuffix(match);
 }
 
 std::string ChessGame::toSan(const ChessMove& move) const {

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -345,6 +345,7 @@ class ChessGame {
     std::string toJson() const;
 
     ChessMove parseSan(const std::string& san) const;
+    std::string toSan(const ChessMove& move) const;
 
     ChessBoard& getPieceBoard();
 

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -346,6 +346,7 @@ class ChessGame {
 
     ChessMove parseSan(const std::string& san) const;
     std::string toSan(const ChessMove& move) const;
+    static std::string normalizeSan(const std::string& san);
 
     ChessBoard& getPieceBoard();
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1338,17 +1338,11 @@ TEST_CASE("ChessGame: toSan queenside castling O-O-O", "[ChessGame][SAN]") {
     REQUIRE(game->toSan(ChessMove(0, 4, 0, 2)) == "O-O-O");
 }
 
-TEST_CASE("ChessGame: toSan check suffix Bb5+", "[ChessGame][SAN]") {
-    // Italian game position: white bishop to b5 giving check
-    auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 3");
+TEST_CASE("ChessGame: toSan checkmate suffix Qxf7#", "[ChessGame][SAN]") {
+    // Scholar's mate setup: queen on f3 captures f7 delivering checkmate.
+    auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
     REQUIRE(game != nullptr);
-    // Bishop from c4 (x=3,y=2) to b5 (x=4,y=1) — check via pin on c6 knight?
-    // Actually Bb5 doesn't check from that position. Let me use a proper check.
-    // Let's use scholar's mate: Qf3 to f7 → checkmate
-    auto game2 = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
-    REQUIRE(game2 != nullptr);
-    // Queen from f3 (x=2,y=5) captures f7 (x=6,y=5) — checkmate
-    REQUIRE(game2->toSan(ChessMove(2, 5, 6, 5)) == "Qxf7#");
+    REQUIRE(game->toSan(ChessMove(2, 5, 6, 5)) == "Qxf7#");
 }
 
 TEST_CASE("ChessGame: toSan promotion e8=Q", "[ChessGame][SAN]") {
@@ -1366,10 +1360,7 @@ TEST_CASE("ChessGame: toSan promotion capture exd8=N+", "[ChessGame][SAN]") {
     // White pawn on e7, black rook on d8, black king on g8.
     auto game = ChessGame::fromFen("3r2k1/4P3/8/8/8/8/8/4K3 w - - 0 1");
     REQUIRE(game != nullptr);
-    // Pawn on e7 (6,4) captures d8 rook (7,3) promoting to knight → check on g8?
-    // Knight on d8 attacks c6, b7, e6, f7 — doesn't check g8. Use queen promo instead.
-    // exd8=Q+ (queen on d8 checks along d8-g8? No, that's diagonal d8→e7→f6→g5. Not a line.)
-    // Actually queen on d8 attacks along rank 8: d8→e8→f8→g8 → yes, checks!
+    // Pawn on e7 captures d8 rook, promoting to queen — checks king on g8 along rank 8.
     REQUIRE(game->toSan(ChessMove(6, 4, 7, 3, QUEEN)) == "exd8=Q+");
 }
 
@@ -1898,14 +1889,8 @@ TEST_CASE("ChessGame::fromFen: rejects pawn on rank 8", "[ChessGame][FEN]") {
 }
 
 TEST_CASE("ChessGame::fromFen: rejects side not to move in check", "[ChessGame][FEN]") {
-    // White to move, black king on e8 is attacked by white rook on e1 → invalid
-    // (side not to move = black is in check)
-    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KR2 w - - 0 1");
-    // Wait — rook on f1 doesn't attack e8. Use rook on e-file instead.
-    // "4k3/8/8/8/8/8/8/R3K3 w - - 0 1" — rook on a1 doesn't check e8.
-    // Need: white rook on e-file with no pieces between it and the black king on e8.
-    // "4k3/8/8/8/8/8/8/3KR3" — rook on e1, king on d1, black king e8 → rook checks e8!
-    game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
+    // White to move, but black king on e8 is attacked by white rook on e1 → invalid.
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
     REQUIRE(game == nullptr);
 }
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1284,15 +1284,24 @@ TEST_CASE("ChessGame: parseSan invalid move returns end sentinel", "[ChessGame][
     REQUIRE(move.isEnd());
 }
 
-TEST_CASE("ChessGame: parseSan with check suffix Bb8+", "[ChessGame][SAN]") {
+TEST_CASE("ChessGame: parseSan with check suffix Bb5+", "[ChessGame][SAN]") {
+    // Bishop to b5 gives check on black king e8 (diagonal b5-e8).
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(3, 5, new Bishop(WHITE, false, cb.b));  // Bishop on f4
     cb.activate();
-    ChessMove move = cb.game.parseSan("Bb8+");
+    // Bf4 can go to b8 (no check) or various squares. Let's use Bc7 which
+    // goes to c7 (6,2) — does it check? c7 to e8 is not a diagonal.
+    // Try: place bishop on d3 (2,3), move to b5 (4,1) — b5 to e8: diagonal!
+    CustomBoard cb2;
+    cb2.place(0, 4, new King(WHITE, cb2.b));
+    cb2.place(7, 4, new King(BLACK, cb2.b));
+    cb2.place(2, 3, new Bishop(WHITE, false, cb2.b));  // Bishop on d3
+    cb2.activate();
+    ChessMove move = cb2.game.parseSan("Bb5+");
     REQUIRE(!move.isEnd());
-    REQUIRE(move.getEndX() == 7);
+    REQUIRE(move.getEndX() == 4);
     REQUIRE(move.getEndY() == 1);
 }
 
@@ -1393,6 +1402,61 @@ TEST_CASE("ChessGame: toSan disambiguation by rank R1e3", "[ChessGame][SAN]") {
     cb.activate();
     // Both rooks on a-file can reach a3 (x=2,y=0).
     REQUIRE(cb.game.toSan(ChessMove(0, 0, 2, 0)) == "R1a3");
+}
+
+// ============================================================================
+// SAN Suffix Validation (SPEC 6.2.8)
+// ============================================================================
+
+TEST_CASE("ChessGame: parseSan rejects + when move does not give check", "[ChessGame][SAN]") {
+    ChessGame game;
+    // e4+ — pawn push does not give check
+    ChessMove move = game.parseSan("e4+");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects # when move is not checkmate", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("e4#");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts correct + suffix", "[ChessGame][SAN]") {
+    // White bishop on d3 can go to b5 giving check to black king on e8.
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/3B4/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("Bb5+");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts correct # suffix", "[ChessGame][SAN]") {
+    // Scholar's mate: Qxf7#
+    auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("Qxf7#");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts move without suffix even if it gives check", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 2 3");
+    REQUIRE(game != nullptr);
+    // Qxf7 without suffix — should be accepted per SPEC 6.2.8
+    ChessMove move = game->parseSan("Qxf7");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects digit-zero castling 0-0", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/5NP1/PPPPPPBP/RNBQK2R w KQkq - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("0-0");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects lowercase promotion =q", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("8/4P1k1/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("e8=q");
+    REQUIRE(move.isEnd());
 }
 
 // ============================================================================

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1715,6 +1715,117 @@ TEST_CASE("ChessGame::fromFen: legal moves from loaded position work", "[ChessGa
 }
 
 // ============================================================================
+// FEN Validation (SPEC 5.3)
+// ============================================================================
+
+// --- Syntactic validation (must reject) ---
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of fields (5 fields)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of fields (7 fields)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 extra");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects wrong number of ranks (7 ranks)", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects rank with too many squares", "[ChessGame][FEN]") {
+    // Rank 1 has 9 squares: RNBQKBNRR
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects rank with too few squares", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBN w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects consecutive digits in rank", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/44/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid piece letter", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNXQKBNR w KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid active color", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid castling characters", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQxq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects invalid en passant square", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq z9 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects negative halfmove clock", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - -1 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects fullmove number less than 1", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 0");
+    REQUIRE(game == nullptr);
+}
+
+// --- Position validation (should reject) ---
+
+TEST_CASE("ChessGame::fromFen: rejects missing white king", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/8 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects missing black king", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("8/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects two white kings", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KK3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects pawn on rank 1", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/P3K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects pawn on rank 8", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("p3k3/8/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects side not to move in check", "[ChessGame][FEN]") {
+    // White to move, black king on e8 is attacked by white rook on e1 → invalid
+    // (side not to move = black is in check)
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KR2 w - - 0 1");
+    // Wait — rook on f1 doesn't attack e8. Use rook on e-file instead.
+    // "4k3/8/8/8/8/8/8/R3K3 w - - 0 1" — rook on a1 doesn't check e8.
+    // Need: white rook on e-file with no pieces between it and the black king on e8.
+    // "4k3/8/8/8/8/8/8/3KR3" — rook on e1, king on d1, black king e8 → rook checks e8!
+    game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects adjacent kings", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("8/8/8/8/8/8/8/3Kk3 w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+// ============================================================================
 // Independent castling rights
 // ============================================================================
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1452,6 +1452,50 @@ TEST_CASE("ChessGame: parseSan rejects digit-zero castling 0-0", "[ChessGame][SA
     REQUIRE(move.isEnd());
 }
 
+// ============================================================================
+// SAN Normalization (SPEC 6.3)
+// ============================================================================
+
+TEST_CASE("ChessGame: normalizeSan strips assessment glyphs", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("Nf3!") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("Bxh7+??") == "Bxh7+");
+    REQUIRE(ChessGame::normalizeSan("O-O!!") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("e4!?") == "e4");
+    REQUIRE(ChessGame::normalizeSan("d5?!") == "d5");
+    REQUIRE(ChessGame::normalizeSan("Qh4?") == "Qh4");
+}
+
+TEST_CASE("ChessGame: normalizeSan strips NAGs", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("Nf3$1") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("e4$6") == "e4");
+    REQUIRE(ChessGame::normalizeSan("Bxh7+$2") == "Bxh7+");
+}
+
+TEST_CASE("ChessGame: normalizeSan converts digit-zero castling", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("0-0") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("0-0-0") == "O-O-O");
+    REQUIRE(ChessGame::normalizeSan("0-0+") == "O-O+");
+    REQUIRE(ChessGame::normalizeSan("0-0-0#") == "O-O-O#");
+}
+
+TEST_CASE("ChessGame: normalizeSan strips whitespace", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("  Nf3  ") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("\tBb5+\n") == "Bb5+");
+}
+
+TEST_CASE("ChessGame: normalizeSan preserves canonical SAN", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("e4") == "e4");
+    REQUIRE(ChessGame::normalizeSan("Nf3") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("O-O") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("Qxf7#") == "Qxf7#");
+    REQUIRE(ChessGame::normalizeSan("e8=Q") == "e8=Q");
+}
+
+TEST_CASE("ChessGame: normalizeSan combined annotations", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("  0-0!!$3  ") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("Nf3!$1") == "Nf3");
+}
+
 TEST_CASE("ChessGame: parseSan rejects lowercase promotion =q", "[ChessGame][SAN]") {
     auto game = ChessGame::fromFen("8/4P1k1/8/8/8/8/8/4K3 w - - 0 1");
     REQUIRE(game != nullptr);

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1307,6 +1307,95 @@ TEST_CASE("ChessGame: parseSan rejects false capture annotation", "[ChessGame][S
 }
 
 // ============================================================================
+// SAN Output (toSan)
+// ============================================================================
+
+TEST_CASE("ChessGame: toSan pawn push e2e4", "[ChessGame][SAN]") {
+    ChessGame game;
+    REQUIRE(game.toSan(ChessMove(1, 4, 3, 4)) == "e4");
+}
+
+TEST_CASE("ChessGame: toSan knight move Nf3", "[ChessGame][SAN]") {
+    ChessGame game;
+    REQUIRE(game.toSan(ChessMove(0, 6, 2, 5)) == "Nf3");
+}
+
+TEST_CASE("ChessGame: toSan pawn capture with file exd5", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->toSan(ChessMove(3, 4, 4, 3)) == "exd5");
+}
+
+TEST_CASE("ChessGame: toSan kingside castling O-O", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/5NP1/PPPPPPBP/RNBQK2R w KQkq - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->toSan(ChessMove(0, 4, 0, 6)) == "O-O");
+}
+
+TEST_CASE("ChessGame: toSan queenside castling O-O-O", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/2NQB3/PPPPPPPP/R3KBNR w KQkq - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->toSan(ChessMove(0, 4, 0, 2)) == "O-O-O");
+}
+
+TEST_CASE("ChessGame: toSan check suffix Bb5+", "[ChessGame][SAN]") {
+    // Italian game position: white bishop to b5 giving check
+    auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 3");
+    REQUIRE(game != nullptr);
+    // Bishop from c4 (x=3,y=2) to b5 (x=4,y=1) — check via pin on c6 knight?
+    // Actually Bb5 doesn't check from that position. Let me use a proper check.
+    // Let's use scholar's mate: Qf3 to f7 → checkmate
+    auto game2 = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
+    REQUIRE(game2 != nullptr);
+    // Queen from f3 (x=2,y=5) captures f7 (x=6,y=5) — checkmate
+    REQUIRE(game2->toSan(ChessMove(2, 5, 6, 5)) == "Qxf7#");
+}
+
+TEST_CASE("ChessGame: toSan promotion e8=Q", "[ChessGame][SAN]") {
+    // Black king away from e-file so pawn can push to e8.
+    auto game = ChessGame::fromFen("6k1/4P3/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->toSan(ChessMove(6, 4, 7, 4, QUEEN)) == "e8=Q+");
+    // Also test non-check promotion
+    auto game2 = ChessGame::fromFen("8/4P1k1/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game2 != nullptr);
+    REQUIRE(game2->toSan(ChessMove(6, 4, 7, 4, QUEEN)) == "e8=Q");
+}
+
+TEST_CASE("ChessGame: toSan promotion capture exd8=N+", "[ChessGame][SAN]") {
+    // White pawn on e7, black rook on d8, black king on g8.
+    auto game = ChessGame::fromFen("3r2k1/4P3/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    // Pawn on e7 (6,4) captures d8 rook (7,3) promoting to knight → check on g8?
+    // Knight on d8 attacks c6, b7, e6, f7 — doesn't check g8. Use queen promo instead.
+    // exd8=Q+ (queen on d8 checks along d8-g8? No, that's diagonal d8→e7→f6→g5. Not a line.)
+    // Actually queen on d8 attacks along rank 8: d8→e8→f8→g8 → yes, checks!
+    REQUIRE(game->toSan(ChessMove(6, 4, 7, 3, QUEEN)) == "exd8=Q+");
+}
+
+TEST_CASE("ChessGame: toSan disambiguation by file Rad1", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(3, 0, new Rook(WHITE, false, cb.b));  // a4
+    cb.place(3, 7, new Rook(WHITE, true, cb.b));    // h4
+    cb.activate();
+    // Both rooks on rank 4 can reach d4 (x=3,y=3).
+    REQUIRE(cb.game.toSan(ChessMove(3, 0, 3, 3)) == "Rad4");
+}
+
+TEST_CASE("ChessGame: toSan disambiguation by rank R1e3", "[ChessGame][SAN]") {
+    CustomBoard cb;
+    cb.place(0, 4, new King(WHITE, cb.b));
+    cb.place(7, 4, new King(BLACK, cb.b));
+    cb.place(0, 0, new Rook(WHITE, false, cb.b));  // a1
+    cb.place(4, 0, new Rook(WHITE, false, cb.b));   // a5
+    cb.activate();
+    // Both rooks on a-file can reach a3 (x=2,y=0).
+    REQUIRE(cb.game.toSan(ChessMove(0, 0, 2, 0)) == "R1a3");
+}
+
+// ============================================================================
 // Draw Detection
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds static `normalizeSan()` to `ChessGame` per SPEC 6.3
- Converts annotated SAN from external sources into canonical form: strips NAGs, assessment glyphs, converts digit-zero castling, trims whitespace
- Preserves check/checkmate suffixes

## Dependencies
- Depends on PR #29 (step 8f) and earlier PRs

## Test plan
- [x] 6 new tests covering all normalization features and edge cases
- [x] All 184 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)