### PR TITLE
chess: termination priority — checkmate over draws (step 8i)

### DIFF
--- a/chess/Main.cpp
+++ b/chess/Main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
             }
         } else {
             // Try SAN first (e.g., "e4", "Nf3", "O-O", "exd5", "e8=Q").
-            // Falls back to LAN (e.g., "e2-e4", "e2e4") if SAN doesn't match.
+            // Falls back to LAN (e.g., "e2e4") if SAN doesn't match.
             ChessMove move = game.parseSan(input);
             if (move.isEnd()) {
                 // SAN didn't match — try LAN. For LAN promotion, prompt the user.

--- a/chess/bridge.cpp
+++ b/chess/bridge.cpp
@@ -57,23 +57,23 @@ json handleMakeMove(BridgeContext& ctx, const json& cmd) {
     // Try SAN first, fall back to LAN (same logic as Main.cpp)
     ChessMove move = ctx.game->parseSan(moveStr);
     if (move.isEnd()) {
-        // Validate LAN format before constructing ChessMove (constructor asserts valid coords).
-        // LAN format: "a1b2", "a1-b2", or with promotion suffix "a7a8q", "a7-a8q".
-        // Minimum length is 4 (e.g., "e2e4"), with optional separator and promotion char.
+        // Validate LAN format before constructing ChessMove.
+        // Canonical LAN: "a1b2" or with promotion "a7a8q" (no separator).
+        // Also accept hyphenated/spaced forms ("a1-b2", "a1 b2") by stripping the separator.
+        std::string lanStr = moveStr;
+        if (lanStr.size() >= 3 && (lanStr[2] == '-' || lanStr[2] == ' ')) {
+            lanStr.erase(2, 1);  // strip separator to canonical form
+        }
         bool validLan = false;
-        if (moveStr.size() >= 4) {
-            char f1 = moveStr[0], r1 = moveStr[1];
-            int offset = (moveStr[2] == '-' || moveStr[2] == ' ') ? 1 : 0;
-            if (moveStr.size() >= (size_t)(4 + offset)) {
-                char f2 = moveStr[2 + offset], r2 = moveStr[3 + offset];
-                validLan = (f1 >= 'a' && f1 <= 'h' && r1 >= '1' && r1 <= '8' &&
-                            f2 >= 'a' && f2 <= 'h' && r2 >= '1' && r2 <= '8');
-            }
+        if (lanStr.size() >= 4 && lanStr.size() <= 5) {
+            char f1 = lanStr[0], r1 = lanStr[1], f2 = lanStr[2], r2 = lanStr[3];
+            validLan = (f1 >= 'a' && f1 <= 'h' && r1 >= '1' && r1 <= '8' &&
+                        f2 >= 'a' && f2 <= 'h' && r2 >= '1' && r2 <= '8');
         }
         if (!validLan) {
             return makeError("illegal or invalid move: " + moveStr);
         }
-        move = ChessMove(moveStr.c_str());
+        move = ChessMove(lanStr.c_str());
     }
 
     if (!ctx.game->makeMove(move)) {

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1310,13 +1310,17 @@ std::string ChessGame::toFen() const {
 ChessMove ChessGame::parseSan(const std::string& san) const {
     if (san.empty()) return ChessMove();
 
-    // Strip and record check/checkmate suffixes (+, #).
+    // Strip and record check/checkmate suffix (+, #).
+    // Only one suffix character is canonical; reject ++, ##, +#, etc.
     std::string s = san;
     bool hasCheck = false, hasCheckmate = false;
-    while (!s.empty() && (s.back() == '+' || s.back() == '#')) {
+    if (!s.empty() && (s.back() == '+' || s.back() == '#')) {
         if (s.back() == '#') hasCheckmate = true;
         else hasCheck = true;
         s.pop_back();
+        // Reject if another suffix character follows (non-canonical).
+        if (!s.empty() && (s.back() == '+' || s.back() == '#'))
+            return ChessMove();
     }
     if (s.empty()) return ChessMove();
 
@@ -1666,6 +1670,11 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
         if (enPassant[1] < '1' || enPassant[1] > '8') return nullptr;
         // ep target must be on rank 3 or 6
         if (enPassant[1] != '3' && enPassant[1] != '6') return nullptr;
+        // ep rank must be consistent with active color:
+        // rank 3 target means white just double-pushed (e2→e4, target e3), so it's black's turn.
+        // rank 6 target means black just double-pushed (d7→d5, target d6), so it's white's turn.
+        if (enPassant[1] == '3' && activeColor != "b") return nullptr;
+        if (enPassant[1] == '6' && activeColor != "w") return nullptr;
     }
 
     // Validate and parse piece placement.
@@ -1686,8 +1695,10 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     if (ranks.size() != 8) return nullptr;
 
     // Validate each rank: no consecutive digits, exactly 8 squares, valid piece chars.
-    // Also count kings and check for pawns on back ranks.
+    // Also count kings, pawns, and total pieces; check for pawns on back ranks.
     int whiteKings = 0, blackKings = 0;
+    int whitePieces = 0, blackPieces = 0;
+    int whitePawns = 0, blackPawns = 0;
     int whiteKingX = -1, whiteKingY = -1, blackKingX = -1, blackKingY = -1;
 
     // Build a piece map: ranks[0] = rank 8 (x=7), ranks[7] = rank 1 (x=0).
@@ -1721,6 +1732,10 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
                     else         { blackKings++; blackKingX = boardX; blackKingY = squares; }
                 }
 
+                // Count pieces and pawns per side.
+                if (isWhite) { whitePieces++; if (lower == 'p') whitePawns++; }
+                else         { blackPieces++; if (lower == 'p') blackPawns++; }
+
                 pieces.push_back({boardX, squares, lower, isWhite});
                 squares++;
             }
@@ -1730,6 +1745,10 @@ std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
 
     // Exactly one king per side.
     if (whiteKings != 1 || blackKings != 1) return nullptr;
+
+    // No more than 16 pieces per side, no more than 8 pawns per side.
+    if (whitePieces > 16 || blackPieces > 16) return nullptr;
+    if (whitePawns > 8 || blackPawns > 8) return nullptr;
 
     // Kings must not be adjacent.
     if (std::abs(whiteKingX - blackKingX) <= 1 && std::abs(whiteKingY - blackKingY) <= 1)
@@ -1876,14 +1895,16 @@ int ChessGame::positionCount() const {
 }
 
 bool ChessGame::canClaimDraw() const {
-    // Per SPEC 4.5: checkmate has priority over claimable draws.
-    if (checkmate(true) || checkmate(false)) return false;
+    // Per SPEC 4.5: checkmate and stalemate have priority over claimable draws.
+    // Only the side to move can be in checkmate or stalemate.
+    if (checkmate(whiteTurn) || stalemate(whiteTurn)) return false;
     return halfmoveClock >= 100 || positionCount() >= 3;
 }
 
 bool ChessGame::isAutomaticDraw() const {
-    // Per SPEC 4.5: checkmate has priority over automatic draws.
-    if (checkmate(true) || checkmate(false)) return false;
+    // Per SPEC 4.5: checkmate and stalemate have priority over automatic draws.
+    // Only the side to move can be in checkmate or stalemate.
+    if (checkmate(whiteTurn) || stalemate(whiteTurn)) return false;
     return halfmoveClock >= 150 || positionCount() >= 5;
 }
 

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -34,11 +34,10 @@ ChessMove::ChessMove(int sX, int sY, int eX, int eY)
     ey = (int8_t)eY;
     repr[0] = fileLetters[sy];
     repr[1] = ChessPiece::digits[sx + 1];
-    repr[2] = '-';
-    repr[3] = fileLetters[ey];
-    repr[4] = ChessPiece::digits[ex + 1];
-    repr[5] = '\0';
-    repr[6] = repr[7] = '\0';
+    repr[2] = fileLetters[ey];
+    repr[3] = ChessPiece::digits[ex + 1];
+    repr[4] = '\0';
+    repr[5] = repr[6] = repr[7] = '\0';
 }
 
 // 5-arg ctor (with promotion) — delegates to 4-arg
@@ -52,20 +51,49 @@ ChessMove::ChessMove(int sX, int sY, int eX, int eY, PieceType promo)
             static_assert(PAWN == 0 && ROOK == 1 && KNIGHT == 2 && BISHOP == 3 && QUEEN == 5,
                           "letters[] indexing assumes specific PieceType enum values");
             const char letters[] = {'p', 'r', 'n', 'b', 'k', 'q'};
-            repr[5] = letters[promo];
-            repr[6] = '\0';
+            repr[4] = letters[promo];
+            repr[5] = '\0';
         }
     }
 }
 
-// String ctor — delegates to 4-arg; accepts "a1-b2" or "a1b2" format.
+// String ctor — canonical LAN only: "a1b2" or "a1b2q" (with promotion).
 // Argument mapping: sX=rank(str[1]-'1'), sY=file(str[0]-'a'),
 //   separator at str[2] (' ' or '-') shifts end-square indices by 1.
 ChessMove::ChessMove(const char* const str)
-    : ChessMove((int)(str[1] - '1'),
-                (int)(str[0] - 'a'),
-                (str[2] == ' ' || str[2] == '-') ? (int)(str[4] - '1') : (int)(str[3] - '1'),
-                (str[2] == ' ' || str[2] == '-') ? (int)(str[3] - 'a') : (int)(str[2] - 'a')) {}
+    : sx(-1), sy(-1), ex(-1), ey(-1), promotion(PAWN) {
+    repr[0] = 'E'; repr[1] = 'N'; repr[2] = 'D'; repr[3] = '\0';
+    repr[4] = repr[5] = repr[6] = repr[7] = '\0';
+
+    // Canonical LAN only: 4 chars (e.g., "e2e4") or 5 chars with promotion
+    // (e.g., "e7e8q"). Reject hyphenated or spaced forms.
+    if (str == nullptr) return;
+    size_t len = strlen(str);
+    if (len < 4 || len > 5) return;
+
+    int sY = str[0] - 'a', sX = str[1] - '1';
+    int eY = str[2] - 'a', eX = str[3] - '1';
+    if (sX < 0 || sX > 7 || sY < 0 || sY > 7 ||
+        eX < 0 || eX > 7 || eY < 0 || eY > 7) return;
+
+    sx = (int8_t)sX; sy = (int8_t)sY;
+    ex = (int8_t)eX; ey = (int8_t)eY;
+    repr[0] = str[0]; repr[1] = str[1];
+    repr[2] = str[2]; repr[3] = str[3];
+    repr[4] = '\0';
+
+    if (len == 5) {
+        char pc = str[4];
+        switch (pc) {
+            case 'q': promotion = QUEEN; break;
+            case 'r': promotion = ROOK; break;
+            case 'n': promotion = KNIGHT; break;
+            case 'b': promotion = BISHOP; break;
+            default: sx = -1; return;  // invalid promotion char
+        }
+        repr[4] = pc; repr[5] = '\0';
+    }
+}
 
 // Copy ctor
 ChessMove::ChessMove(const ChessMove& rcm)

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1519,6 +1519,74 @@ std::string ChessGame::toSan(const ChessMove& move) const {
     return san;
 }
 
+std::string ChessGame::normalizeSan(const std::string& san) {
+    std::string s = san;
+
+    // 0. Strip leading/trailing whitespace first so other steps work on clean input.
+    {
+        size_t start = s.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) return "";
+        size_t end = s.find_last_not_of(" \t\n\r");
+        s = s.substr(start, end - start + 1);
+    }
+
+    // 1. Strip NAGs: '$' followed by digits.
+    {
+        std::string result;
+        for (size_t i = 0; i < s.size(); i++) {
+            if (s[i] == '$') {
+                // Skip $ and following digits.
+                i++;
+                while (i < s.size() && s[i] >= '0' && s[i] <= '9') i++;
+                i--;  // loop increment
+            } else {
+                result += s[i];
+            }
+        }
+        s = result;
+    }
+
+    // 2. Strip move assessment glyphs (longest first): !!, ??, !?, ?!, !, ?
+    {
+        // Strip from the end, after any check/checkmate suffix.
+        // First, save and strip check/checkmate suffixes.
+        std::string suffix;
+        while (!s.empty() && (s.back() == '+' || s.back() == '#')) {
+            suffix = s.back() + suffix;
+            s.pop_back();
+        }
+        // Now strip assessment glyphs from the end.
+        bool changed = true;
+        while (changed && !s.empty()) {
+            changed = false;
+            for (const char* glyph : {"!!", "??", "!?", "?!", "!", "?"}) {
+                size_t glen = strlen(glyph);
+                if (s.size() >= glen && s.substr(s.size() - glen) == glyph) {
+                    s.resize(s.size() - glen);
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        s += suffix;
+    }
+
+    // 3. Convert digit-zero castling to letter-O.
+    if (s == "0-0" || s == "0-0+" || s == "0-0#") {
+        s = "O-O" + s.substr(3);
+    } else if (s == "0-0-0" || s == "0-0-0+" || s == "0-0-0#") {
+        s = "O-O-O" + s.substr(5);
+    }
+
+    // 4. Strip leading/trailing whitespace.
+    size_t start = s.find_first_not_of(" \t\n\r");
+    if (start == std::string::npos) return "";
+    size_t end = s.find_last_not_of(" \t\n\r");
+    s = s.substr(start, end - start + 1);
+
+    return s;
+}
+
 std::unique_ptr<ChessGame> ChessGame::fromFen(const std::string& fen) {
     // Split into exactly 6 space-separated fields.
     std::vector<std::string> fields;

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1876,10 +1876,14 @@ int ChessGame::positionCount() const {
 }
 
 bool ChessGame::canClaimDraw() const {
+    // Per SPEC 4.5: checkmate has priority over claimable draws.
+    if (checkmate(true) || checkmate(false)) return false;
     return halfmoveClock >= 100 || positionCount() >= 3;
 }
 
 bool ChessGame::isAutomaticDraw() const {
+    // Per SPEC 4.5: checkmate has priority over automatic draws.
+    if (checkmate(true) || checkmate(false)) return false;
     return halfmoveClock >= 150 || positionCount() >= 5;
 }
 

--- a/chess/chess.cpp
+++ b/chess/chess.cpp
@@ -1292,27 +1292,42 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
     }
     if (s.empty()) return ChessMove();
 
+    // Helper: validate check/checkmate suffix against the actual move result.
+    auto validateSuffix = [&](const ChessMove& m) -> ChessMove {
+        if (!hasCheck && !hasCheckmate) return m;
+        auto copy = ChessGame::fromFen(toFen());
+        if (!copy) return ChessMove();
+        if (!copy->makeMove(ChessMove(m.getStartX(), m.getStartY(),
+                                       m.getEndX(), m.getEndY(), m.getPromotion())))
+            return ChessMove();
+        bool opponent = !whiteTurn;  // the side being checked is the one not moving
+        bool givesCheck = copy->board.checkCheck(opponent);
+        bool givesCheckmate = copy->checkmate(opponent);
+        if (hasCheckmate && !givesCheckmate) return ChessMove();
+        if (hasCheck && !givesCheck) return ChessMove();
+        return m;
+    };
+
     // Castling.
-    if (s == "O-O" || s == "0-0") {
+    if (s == "O-O") {
         int rank = whiteTurn ? 0 : 7;
         ChessMove cm(rank, 4, rank, 6);
-        // Verify it's legal.
         auto moves = getMoves(whiteTurn);
         for (const auto& m : moves) {
             if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
                 m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
-                return m;
+                return validateSuffix(m);
         }
         return ChessMove();
     }
-    if (s == "O-O-O" || s == "0-0-0") {
+    if (s == "O-O-O") {
         int rank = whiteTurn ? 0 : 7;
         ChessMove cm(rank, 4, rank, 2);
         auto moves = getMoves(whiteTurn);
         for (const auto& m : moves) {
             if (m.getStartX() == cm.getStartX() && m.getStartY() == cm.getStartY() &&
                 m.getEndX() == cm.getEndX() && m.getEndY() == cm.getEndY())
-                return m;
+                return validateSuffix(m);
         }
         return ChessMove();
     }
@@ -1324,10 +1339,10 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         if (eq != std::string::npos && eq + 1 < s.size()) {
             char pc = s[eq + 1];
             switch (pc) {
-                case 'Q': case 'q': promo = QUEEN; break;
-                case 'R': case 'r': promo = ROOK; break;
-                case 'B': case 'b': promo = BISHOP; break;
-                case 'N': case 'n': promo = KNIGHT; break;
+                case 'Q': promo = QUEEN; break;
+                case 'R': promo = ROOK; break;
+                case 'B': promo = BISHOP; break;
+                case 'N': promo = KNIGHT; break;
                 default: return ChessMove();
             }
             s = s.substr(0, eq);
@@ -1413,11 +1428,7 @@ ChessMove ChessGame::parseSan(const std::string& san) const {
         if (!isCapture) return ChessMove();
     }
 
-    // Note: check (+) and checkmate (#) annotations are accepted but not
-    // validated, as verification would require simulating the move. These
-    // are informational annotations per SAN convention.
-
-    return match;
+    return validateSuffix(match);
 }
 
 std::string ChessGame::toSan(const ChessMove& move) const {

--- a/chess/chess.h
+++ b/chess/chess.h
@@ -346,6 +346,7 @@ class ChessGame {
 
     ChessMove parseSan(const std::string& san) const;
     std::string toSan(const ChessMove& move) const;
+    static std::string normalizeSan(const std::string& san);
 
     ChessBoard& getPieceBoard();
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1354,12 +1354,9 @@ TEST_CASE("ChessGame: toSan check suffix Bb5+", "[ChessGame][SAN]") {
     // Italian game position: white bishop to b5 giving check
     auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 3");
     REQUIRE(game != nullptr);
-    // Bishop from c4 (x=3,y=2) to b5 (x=4,y=1) — check via pin on c6 knight?
-    // Actually Bb5 doesn't check from that position. Let me use a proper check.
-    // Let's use scholar's mate: Qf3 to f7 → checkmate
+    // Scholar's mate setup: queen on f3 captures f7 delivering checkmate.
     auto game2 = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
     REQUIRE(game2 != nullptr);
-    // Queen from f3 (x=2,y=5) captures f7 (x=6,y=5) — checkmate
     REQUIRE(game2->toSan(ChessMove(2, 5, 6, 5)) == "Qxf7#");
 }
 
@@ -1378,10 +1375,7 @@ TEST_CASE("ChessGame: toSan promotion capture exd8=N+", "[ChessGame][SAN]") {
     // White pawn on e7, black rook on d8, black king on g8.
     auto game = ChessGame::fromFen("3r2k1/4P3/8/8/8/8/8/4K3 w - - 0 1");
     REQUIRE(game != nullptr);
-    // Pawn on e7 (6,4) captures d8 rook (7,3) promoting to knight → check on g8?
-    // Knight on d8 attacks c6, b7, e6, f7 — doesn't check g8. Use queen promo instead.
-    // exd8=Q+ (queen on d8 checks along d8-g8? No, that's diagonal d8→e7→f6→g5. Not a line.)
-    // Actually queen on d8 attacks along rank 8: d8→e8→f8→g8 → yes, checks!
+    // Pawn on e7 captures d8 rook, promoting to queen — checks king on g8 along rank 8.
     REQUIRE(game->toSan(ChessMove(6, 4, 7, 3, QUEEN)) == "exd8=Q+");
 }
 
@@ -1474,11 +1468,10 @@ TEST_CASE("ChessGame: parseSan rejects non-canonical double hash ##", "[ChessGam
 }
 
 TEST_CASE("ChessGame: parseSan accepts + on a checkmating move", "[ChessGame][SAN]") {
-    // Back-rank mate: Rd8# — but + should also be accepted since checkmate implies check.
+    // Rd8 delivers checkmate; + is accepted because checkmate implies check.
     auto game = ChessGame::fromFen("6k1/5ppp/8/8/8/8/8/3RR1K1 w - - 0 1");
     REQUIRE(game != nullptr);
     ChessMove move = game->parseSan("Rd8+");
-    // Rd8 delivers checkmate; + is accepted because checkmate implies check.
     REQUIRE_FALSE(move.isEnd());
 }
 
@@ -1677,27 +1670,13 @@ TEST_CASE("ChessGame: pawn move resets 50-move counter for draw", "[ChessGame][D
 
 TEST_CASE("ChessGame: position identity ignores ep square when no legal capture exists",
           "[ChessGame][Draw]") {
-    // The standard initial position + 1.e4 creates an ep target on e3, but no
-    // black pawn is on d4 or f4 to capture it. So for position identity, the ep
-    // field should be ignored.
-    //
-    // Play: 1. e4 Nc6  2. Nf3 Nb8  3. Ng1 Nc6  4. Ng1 Nb8  5. ...
-    // After 2. Nf3 Nb8: board = initial except e-pawn on e4, black to move
-    // After 4. Ng1 Nb8: same board, black to move = second occurrence
-    //
-    // But we need a third occurrence. Use a different approach:
-    // Start from a FEN where a double push just happened (ep target set) but
-    // no enemy pawn can capture. Then cycle to repeat.
-
-    // Use fromFen to set up: pawn already on a4, black pawn on h7,
-    // black to move, ep=a3 (irrelevant since no black pawn near a-file).
+    // Start from a FEN with an ep target (a3) but no black pawn on an adjacent
+    // file to capture. The ep field should be ignored for position identity,
+    // allowing threefold repetition via king shuffling.
     auto game = ChessGame::fromFen("4k3/7p/8/8/P7/8/8/4K3 b - a3 0 1");
     REQUIRE(game != nullptr);
 
-    // Position 1 (from FEN): kings e1/e8, white pawn a4, black pawn h7, black to move
-    // Note: ep=a3 in FEN but since no legal capture, position key should use "-"
-
-    // 1... Kd8  2. Kd1  3... Ke8  4. Ke1 → position 2 (same board, black to move)
+    // Cycle kings to repeat the position three times.
     REQUIRE(game->makeMove(ChessMove(7, 4, 7, 3)));  // 1... Kd8
     REQUIRE(game->makeMove(ChessMove(0, 4, 0, 3)));  // 2. Kd1
     REQUIRE(game->makeMove(ChessMove(7, 3, 7, 4)));  // 2... Ke8
@@ -1790,55 +1769,10 @@ TEST_CASE("ChessGame: initial position is NOT insufficient material", "[ChessGam
 // ============================================================================
 
 TEST_CASE("ChessGame: checkmate takes priority over 75-move automatic draw", "[ChessGame][Draw]") {
-    // Black king g8, black rook f8, white rook e1, white king a1. White to move.
-    // Re8# delivers back-rank checkmate (rook defended by... itself is the only
-    // piece on rank 8). Actually: Rxf8# — captures the rook, but that's a capture
-    // which resets halfmove. Use a different setup.
-    // White rook on a8, white king on a1, black king on c8, black pawn b7.
-    // Ra8 is already on a8 — move to c8? No, that's the king.
-    // Simpler: White queen h1, white bishop g2. Black king h8, black pawn g7.
-    // Qh7# doesn't work (pawn on g7 blocks?). Let me think...
-    // Back-rank with queen+bishop: Qh7, bishop on b1 defends h7 along diagonal.
-    // Actually just use queen + rook for a simple mating pattern.
-    // White: Kg1 (0,6), Qd1 (0,3), Rd7 (6,3). Black: Kg8 (7,6), Rf8 (7,5), pawn g7.
-    // Qd8 captures? No...
-    // Simplest: scholar's mate but with high halfmove clock.
-    // Kf3, Qf7, against Ke8 (and block all escapes). Qf7 is already check...
-    // Let me just use a 2-rook back rank mate.
-    // White: Ra1, Rb1, Ka3. Black: Ka8, pawns a7 b7. halfmove=149.
-    // Rb8# — rook to b8 (7,1). Black king a8 (7,0). a7 (6,0) has pawn.
-    // Is b8 defended? Ra1 on (0,0) doesn't defend b8. But wait — Rb8 is (7,1),
-    // and Ra1 is on a-file. Not defending. Hmm.
-    // Actually: Ra7, Rb1. Rb8#. Ra7 (6,0) blocks a7 escape.
-    // No — let me use: white rooks on a-file and b-file, high rank.
-    // Rb7 (6,1) and Ra1 (0,0), Kc1 (0,2). Black: Ka8 (7,0), pawn a6 (5,0).
-    // Rb8# — rook from b7 to b8. But black king can't go to a7 (blocked by...
-    // Rb7 is moving to b8, so b7 is vacated. King can go to a7 (6,0) if not attacked.
-    // Ra1 doesn't attack a7 directly. Hmm.
-    //
-    // I'll use a simpler approach: set the halfmove clock directly.
-    // Rook on e1, rook on d1, king a1. Black: king h8, pawns g7 h7 f7.
-    // Re8# — rook to e8 (7,4). Defended by Rd1? No. Let me just use a queen mate.
-    //
-    // Actually the simplest back rank mate: K on g1, R on d8, black K on g8 with
-    // pawns f7 g7 h7. Rd8 is already check. But I need to DELIVER it.
-    //
-    // Position: Kg1 (0,6), Rd1 (0,3). Black: Kg8 (7,6), Rf8 (7,5), pf7 (6,5), pg7 (6,6), ph7 (6,7).
-    // White plays Rd8 (0,3 -> 7,3). Check along rank 8? No, Rf8 blocks.
-    // Rxf8? That's a capture (resets clock).
-    //
-    // OK let me try: two white rooks, one delivers mate defended by the other.
-    // Rd1 (0,3), Re1 (0,4), Kg1 (0,6). Black: Kg8 (7,6), pf7, pg7, ph7.
-    // Rd8# — rook from d1 to d8 (7,3). Is black in check? Rd8 attacks along rank 8
-    // but Rf8... wait, there's no Rf8 here. Rank 8: only king on g8. So Rd8 checks
-    // the king on g8? d8 (7,3) to g8 (7,6): same rank, nothing between d8 and g8
-    // on rank 8 (e8, f8 are empty). Yes, check! King can go to: f8 (7,5) — is it
-    // attacked? Rd8 on d8 attacks rank 8 (including f8). h8 (7,7) — attacked by Rd8.
-    // Kh7 (6,7) — has own pawn. Kf7? (6,5) — own pawn. Can king capture Rd8? (7,3)
-    // That's too far. So: h8 attacked, f8 attacked, g7 own pawn, h7 own pawn, f7 own
-    // pawn. No legal moves → checkmate! And Re1 defends... actually Re1 doesn't need
-    // to defend Rd8 since the king can't reach d8 anyway. The point is all escape squares
-    // are blocked by own pawns or attacked by the rook.
+    // Two white rooks + king vs black king behind pawns. Rd8# is back-rank mate:
+    // rook on d8 checks along rank 8, king's escape squares (f8, h8) are also
+    // attacked by the rook, and f7/g7/h7 are blocked by own pawns.
+    // Halfmove clock at 149 — the mating move pushes it to 150 (75-move threshold).
     auto game = ChessGame::fromFen("6k1/5ppp/8/8/8/8/8/3RR1K1 w - - 149 100");
     REQUIRE(game != nullptr);
     REQUIRE_FALSE(game->isAutomaticDraw());
@@ -2154,14 +2088,8 @@ TEST_CASE("ChessGame::fromFen: rejects pawn on rank 8", "[ChessGame][FEN]") {
 }
 
 TEST_CASE("ChessGame::fromFen: rejects side not to move in check", "[ChessGame][FEN]") {
-    // White to move, black king on e8 is attacked by white rook on e1 → invalid
-    // (side not to move = black is in check)
-    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4KR2 w - - 0 1");
-    // Wait — rook on f1 doesn't attack e8. Use rook on e-file instead.
-    // "4k3/8/8/8/8/8/8/R3K3 w - - 0 1" — rook on a1 doesn't check e8.
-    // Need: white rook on e-file with no pieces between it and the black king on e8.
-    // "4k3/8/8/8/8/8/8/3KR3" — rook on e1, king on d1, black king e8 → rook checks e8!
-    game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
+    // White to move, but black king on e8 is attacked by white rook on e1 → invalid.
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/3KR3 w - - 0 1");
     REQUIRE(game == nullptr);
 }
 

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -2158,16 +2158,26 @@ TEST_CASE("Bridge: make_move with SAN 'e4' succeeds", "[bridge]") {
     REQUIRE(resp["state"]["turn"] == "black");
 }
 
-TEST_CASE("Bridge: make_move with LAN 'e2-e4' succeeds", "[bridge]") {
+TEST_CASE("Bridge: make_move with LAN 'e2e4' succeeds", "[bridge]") {
+    BridgeContext ctx;
+    bridgeCmd(ctx, {{"command", "new_game"}});
+    auto resp = bridgeCmd(ctx, {{"command", "make_move"}, {"move", "e2e4"}});
+    REQUIRE(resp["ok"] == true);
+    REQUIRE(resp["state"]["turn"] == "black");
+    REQUIRE(resp.contains("move_lan"));
+    std::string lan = resp["move_lan"];
+    REQUIRE(lan == "e2e4");
+}
+
+TEST_CASE("Bridge: make_move accepts hyphenated LAN 'e2-e4'", "[bridge]") {
     BridgeContext ctx;
     bridgeCmd(ctx, {{"command", "new_game"}});
     auto resp = bridgeCmd(ctx, {{"command", "make_move"}, {"move", "e2-e4"}});
     REQUIRE(resp["ok"] == true);
     REQUIRE(resp["state"]["turn"] == "black");
-    // move_lan should be present
     REQUIRE(resp.contains("move_lan"));
     std::string lan = resp["move_lan"];
-    REQUIRE(lan == "e2-e4");
+    REQUIRE(lan == "e2e4");  // output is canonical (unhyphenated)
 }
 
 TEST_CASE("Bridge: make_move with illegal move returns ok:false", "[bridge]") {
@@ -2194,12 +2204,12 @@ TEST_CASE("Bridge: from_fen with invalid FEN returns ok:false", "[bridge]") {
     REQUIRE(resp.contains("error"));
 }
 
-TEST_CASE("Bridge: parse_san 'Nf3' returns LAN 'g1-f3'", "[bridge]") {
+TEST_CASE("Bridge: parse_san 'Nf3' returns LAN 'g1f3'", "[bridge]") {
     BridgeContext ctx;
     bridgeCmd(ctx, {{"command", "new_game"}});
     auto resp = bridgeCmd(ctx, {{"command", "parse_san"}, {"san", "Nf3"}});
     REQUIRE(resp["ok"] == true);
-    REQUIRE(resp["lan"] == "g1-f3");
+    REQUIRE(resp["lan"] == "g1f3");
 }
 
 TEST_CASE("Bridge: parse_san with invalid SAN returns ok:false", "[bridge]") {

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -116,6 +116,11 @@ TEST_CASE("ChessMove: string constructor parses 'a1b2' (no separator)", "[ChessM
     REQUIRE(cm.getEndY() == 1);
 }
 
+TEST_CASE("ChessMove: string constructor rejects invalid promotion character", "[ChessMove]") {
+    ChessMove cm("e7e8x");
+    REQUIRE(cm.isEnd());
+}
+
 TEST_CASE("ChessMove: getPromotion returns PAWN for non-promotion move", "[ChessMove]") {
     ChessMove cm(1, 2, 3, 4);
     REQUIRE(cm.getPromotion() == PAWN);
@@ -1468,6 +1473,23 @@ TEST_CASE("ChessGame: parseSan rejects non-canonical double hash ##", "[ChessGam
     REQUIRE(move.isEnd());
 }
 
+TEST_CASE("ChessGame: parseSan accepts + on a checkmating move", "[ChessGame][SAN]") {
+    // Back-rank mate: Rd8# — but + should also be accepted since checkmate implies check.
+    auto game = ChessGame::fromFen("6k1/5ppp/8/8/8/8/8/3RR1K1 w - - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("Rd8+");
+    // Rd8 delivers checkmate; + is accepted because checkmate implies check.
+    REQUIRE_FALSE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects digit-zero queenside castling 0-0-0", "[ChessGame][SAN]") {
+    // Position where queenside castling is legal.
+    auto game = ChessGame::fromFen("r3kbnr/pppppppp/8/8/8/8/PPPPPPPP/R3KBNR w KQkq - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("0-0-0");
+    REQUIRE(move.isEnd());
+}
+
 // ============================================================================
 // SAN Normalization (SPEC 6.3)
 // ============================================================================
@@ -1510,6 +1532,22 @@ TEST_CASE("ChessGame: normalizeSan preserves canonical SAN", "[ChessGame][SAN]")
 TEST_CASE("ChessGame: normalizeSan combined annotations", "[ChessGame][SAN]") {
     REQUIRE(ChessGame::normalizeSan("  0-0!!$3  ") == "O-O");
     REQUIRE(ChessGame::normalizeSan("Nf3!$1") == "Nf3");
+}
+
+TEST_CASE("ChessGame: normalizeSan edge cases", "[ChessGame][SAN]") {
+    // Bare $ with no digits
+    REQUIRE(ChessGame::normalizeSan("Nf3$") == "Nf3");
+    // Multiple consecutive NAGs
+    REQUIRE(ChessGame::normalizeSan("Nf3$1$6") == "Nf3");
+    // Whitespace between move and NAG
+    REQUIRE(ChessGame::normalizeSan("Nf3 $1") == "Nf3");
+    // Castling + glyph + check suffix
+    REQUIRE(ChessGame::normalizeSan("0-0!!+") == "O-O+");
+    REQUIRE(ChessGame::normalizeSan("0-0-0??#") == "O-O-O#");
+    // Empty string
+    REQUIRE(ChessGame::normalizeSan("") == "");
+    // NAG-only input
+    REQUIRE(ChessGame::normalizeSan("$3") == "");
 }
 
 TEST_CASE("ChessGame: parseSan rejects lowercase promotion =q", "[ChessGame][SAN]") {
@@ -1830,6 +1868,15 @@ TEST_CASE("ChessGame: stalemate takes priority over automatic draw", "[ChessGame
     REQUIRE(game->stalemate(false));   // black is stalemated
     REQUIRE_FALSE(game->isAutomaticDraw());  // stalemate has priority
     REQUIRE_FALSE(game->canClaimDraw());     // stalemate has priority
+}
+
+TEST_CASE("ChessGame: automatic draw still triggers in non-mate/stalemate position", "[ChessGame][Draw]") {
+    // K vs K at halfmove=150 — insufficient material AND 75-move threshold.
+    // Neither checkmate nor stalemate, so isAutomaticDraw should return true.
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/8/8/4K3 w - - 150 100");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->isAutomaticDraw());
+    REQUIRE(game->canClaimDraw());
 }
 
 // ============================================================================
@@ -2168,6 +2215,36 @@ TEST_CASE("ChessGame::fromFen: accepts ep rank 6 when white to move", "[ChessGam
     // rank 6 ep: black just double-pushed d7→d5, white to move
     auto game = ChessGame::fromFen("rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w - d6 0 1");
     REQUIRE(game != nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects castling field out of order", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w kqKQ - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects duplicate castling character", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KKkq - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects empty string", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects whitespace-only string", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("   ");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects non-integer halfmove clock", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - abc 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects non-integer fullmove number", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1.5");
+    REQUIRE(game == nullptr);
 }
 
 // ============================================================================

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1284,15 +1284,24 @@ TEST_CASE("ChessGame: parseSan invalid move returns end sentinel", "[ChessGame][
     REQUIRE(move.isEnd());
 }
 
-TEST_CASE("ChessGame: parseSan with check suffix Bb8+", "[ChessGame][SAN]") {
+TEST_CASE("ChessGame: parseSan with check suffix Bb5+", "[ChessGame][SAN]") {
+    // Bishop to b5 gives check on black king e8 (diagonal b5-e8).
     CustomBoard cb;
     cb.place(0, 4, new King(WHITE, cb.b));
     cb.place(7, 4, new King(BLACK, cb.b));
     cb.place(3, 5, new Bishop(WHITE, false, cb.b));  // Bishop on f4
     cb.activate();
-    ChessMove move = cb.game.parseSan("Bb8+");
+    // Bf4 can go to b8 (no check) or various squares. Let's use Bc7 which
+    // goes to c7 (6,2) — does it check? c7 to e8 is not a diagonal.
+    // Try: place bishop on d3 (2,3), move to b5 (4,1) — b5 to e8: diagonal!
+    CustomBoard cb2;
+    cb2.place(0, 4, new King(WHITE, cb2.b));
+    cb2.place(7, 4, new King(BLACK, cb2.b));
+    cb2.place(2, 3, new Bishop(WHITE, false, cb2.b));  // Bishop on d3
+    cb2.activate();
+    ChessMove move = cb2.game.parseSan("Bb5+");
     REQUIRE(!move.isEnd());
-    REQUIRE(move.getEndX() == 7);
+    REQUIRE(move.getEndX() == 4);
     REQUIRE(move.getEndY() == 1);
 }
 
@@ -1393,6 +1402,61 @@ TEST_CASE("ChessGame: toSan disambiguation by rank R1e3", "[ChessGame][SAN]") {
     cb.activate();
     // Both rooks on a-file can reach a3 (x=2,y=0).
     REQUIRE(cb.game.toSan(ChessMove(0, 0, 2, 0)) == "R1a3");
+}
+
+// ============================================================================
+// SAN Suffix Validation (SPEC 6.2.8)
+// ============================================================================
+
+TEST_CASE("ChessGame: parseSan rejects + when move does not give check", "[ChessGame][SAN]") {
+    ChessGame game;
+    // e4+ — pawn push does not give check
+    ChessMove move = game.parseSan("e4+");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects # when move is not checkmate", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("e4#");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts correct + suffix", "[ChessGame][SAN]") {
+    // White bishop on d3 can go to b5 giving check to black king on e8.
+    auto game = ChessGame::fromFen("4k3/8/8/8/8/3B4/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("Bb5+");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts correct # suffix", "[ChessGame][SAN]") {
+    // Scholar's mate: Qxf7#
+    auto game = ChessGame::fromFen("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 3");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("Qxf7#");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan accepts move without suffix even if it gives check", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 2 3");
+    REQUIRE(game != nullptr);
+    // Qxf7 without suffix — should be accepted per SPEC 6.2.8
+    ChessMove move = game->parseSan("Qxf7");
+    REQUIRE(!move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects digit-zero castling 0-0", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/8/5NP1/PPPPPPBP/RNBQK2R w KQkq - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("0-0");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects lowercase promotion =q", "[ChessGame][SAN]") {
+    auto game = ChessGame::fromFen("8/4P1k1/8/8/8/8/8/4K3 w - - 0 1");
+    REQUIRE(game != nullptr);
+    ChessMove move = game->parseSan("e8=q");
+    REQUIRE(move.isEnd());
 }
 
 // ============================================================================

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1452,6 +1452,50 @@ TEST_CASE("ChessGame: parseSan rejects digit-zero castling 0-0", "[ChessGame][SA
     REQUIRE(move.isEnd());
 }
 
+// ============================================================================
+// SAN Normalization (SPEC 6.3)
+// ============================================================================
+
+TEST_CASE("ChessGame: normalizeSan strips assessment glyphs", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("Nf3!") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("Bxh7+??") == "Bxh7+");
+    REQUIRE(ChessGame::normalizeSan("O-O!!") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("e4!?") == "e4");
+    REQUIRE(ChessGame::normalizeSan("d5?!") == "d5");
+    REQUIRE(ChessGame::normalizeSan("Qh4?") == "Qh4");
+}
+
+TEST_CASE("ChessGame: normalizeSan strips NAGs", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("Nf3$1") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("e4$6") == "e4");
+    REQUIRE(ChessGame::normalizeSan("Bxh7+$2") == "Bxh7+");
+}
+
+TEST_CASE("ChessGame: normalizeSan converts digit-zero castling", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("0-0") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("0-0-0") == "O-O-O");
+    REQUIRE(ChessGame::normalizeSan("0-0+") == "O-O+");
+    REQUIRE(ChessGame::normalizeSan("0-0-0#") == "O-O-O#");
+}
+
+TEST_CASE("ChessGame: normalizeSan strips whitespace", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("  Nf3  ") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("\tBb5+\n") == "Bb5+");
+}
+
+TEST_CASE("ChessGame: normalizeSan preserves canonical SAN", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("e4") == "e4");
+    REQUIRE(ChessGame::normalizeSan("Nf3") == "Nf3");
+    REQUIRE(ChessGame::normalizeSan("O-O") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("Qxf7#") == "Qxf7#");
+    REQUIRE(ChessGame::normalizeSan("e8=Q") == "e8=Q");
+}
+
+TEST_CASE("ChessGame: normalizeSan combined annotations", "[ChessGame][SAN]") {
+    REQUIRE(ChessGame::normalizeSan("  0-0!!$3  ") == "O-O");
+    REQUIRE(ChessGame::normalizeSan("Nf3!$1") == "Nf3");
+}
+
 TEST_CASE("ChessGame: parseSan rejects lowercase promotion =q", "[ChessGame][SAN]") {
     auto game = ChessGame::fromFen("8/4P1k1/8/8/8/8/8/4K3 w - - 0 1");
     REQUIRE(game != nullptr);

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -94,20 +94,18 @@ TEST_CASE("ChessMove: self-assignment is safe", "[ChessMove]") {
 TEST_CASE("ChessMove: toString format is 'a1-b2'", "[ChessMove]") {
     // a=y=0 rank1=x=0, b=y=1 rank2=x=1
     ChessMove cm(0, 0, 1, 1);
-    REQUIRE(std::string(cm.toString()) == "a1-b2");
+    REQUIRE(std::string(cm.toString()) == "a1b2");
 }
 
 TEST_CASE("ChessMove: toString for various squares", "[ChessMove]") {
     ChessMove cm(7, 7, 0, 0);  // h8-a1
-    REQUIRE(std::string(cm.toString()) == "h8-a1");
+    REQUIRE(std::string(cm.toString()) == "h8a1");
 }
 
-TEST_CASE("ChessMove: string constructor parses 'a1-b2'", "[ChessMove]") {
+TEST_CASE("ChessMove: string constructor rejects hyphenated 'a1-b2'", "[ChessMove]") {
+    // Canonical LAN has no separator: "a1b2" only. Hyphenated form rejected.
     ChessMove cm("a1-b2");
-    REQUIRE(cm.getStartX() == 0);
-    REQUIRE(cm.getStartY() == 0);
-    REQUIRE(cm.getEndX() == 1);
-    REQUIRE(cm.getEndY() == 1);
+    REQUIRE(cm.isEnd());
 }
 
 TEST_CASE("ChessMove: string constructor parses 'a1b2' (no separator)", "[ChessMove]") {
@@ -136,20 +134,20 @@ TEST_CASE("ChessMove: 5-arg constructor coordinate roundtrip and getPromotion", 
 
 TEST_CASE("ChessMove: toString includes promotion letter for promotion move", "[ChessMove]") {
     ChessMove q(6, 3, 7, 3, QUEEN);
-    REQUIRE(std::string(q.toString()) == "d7-d8q");
+    REQUIRE(std::string(q.toString()) == "d7d8q");
 
     ChessMove r(6, 3, 7, 3, ROOK);
-    REQUIRE(std::string(r.toString()) == "d7-d8r");
+    REQUIRE(std::string(r.toString()) == "d7d8r");
 
     ChessMove n(6, 3, 7, 3, KNIGHT);
-    REQUIRE(std::string(n.toString()) == "d7-d8n");
+    REQUIRE(std::string(n.toString()) == "d7d8n");
 
     ChessMove b(6, 3, 7, 3, BISHOP);
-    REQUIRE(std::string(b.toString()) == "d7-d8b");
+    REQUIRE(std::string(b.toString()) == "d7d8b");
 
     // Non-promotion move has no suffix
     ChessMove plain(1, 2, 3, 4);
-    REQUIRE(std::string(plain.toString()) == "c2-e4");
+    REQUIRE(std::string(plain.toString()) == "c2e4");
 }
 // ============================================================================
 // ChessBoard / ChessGame: initial position
@@ -1808,11 +1806,11 @@ TEST_CASE("toJson: moveHistory grows after moves", "[ChessGame][JSON]") {
 
     game.makeMove(ChessMove(1, 4, 3, 4));  // e2-e4
     json = game.toJson();
-    REQUIRE(json.find("\"moveHistory\":[\"e2-e4\"]") != std::string::npos);
+    REQUIRE(json.find("\"moveHistory\":[\"e2e4\"]") != std::string::npos);
 
     game.makeMove(ChessMove(6, 4, 4, 4));  // e7-e5
     json = game.toJson();
-    REQUIRE(json.find("\"moveHistory\":[\"e2-e4\",\"e7-e5\"]") != std::string::npos);
+    REQUIRE(json.find("\"moveHistory\":[\"e2e4\",\"e7e5\"]") != std::string::npos);
 }
 
 // ============================================================================

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1450,6 +1450,24 @@ TEST_CASE("ChessGame: parseSan rejects digit-zero castling 0-0", "[ChessGame][SA
     REQUIRE(move.isEnd());
 }
 
+TEST_CASE("ChessGame: parseSan rejects non-canonical double suffix ++", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("Nf3++");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects non-canonical mixed suffix +#", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("Qxf7+#");
+    REQUIRE(move.isEnd());
+}
+
+TEST_CASE("ChessGame: parseSan rejects non-canonical double hash ##", "[ChessGame][SAN]") {
+    ChessGame game;
+    ChessMove move = game.parseSan("Qxf7##");
+    REQUIRE(move.isEnd());
+}
+
 // ============================================================================
 // SAN Normalization (SPEC 6.3)
 // ============================================================================
@@ -1803,6 +1821,17 @@ TEST_CASE("ChessGame: checkmate takes priority over 50-move claimable draw", "[C
     REQUIRE_FALSE(game->canClaimDraw());
 }
 
+TEST_CASE("ChessGame: stalemate takes priority over automatic draw", "[ChessGame][Draw]") {
+    // Stalemate position with high halfmove clock (>= 150).
+    // Black king on a8, white queen on b6, white king on c8 — black to move, no legal moves,
+    // not in check = stalemate.
+    auto game = ChessGame::fromFen("k7/8/1Q6/8/8/8/8/2K5 b - - 150 100");
+    REQUIRE(game != nullptr);
+    REQUIRE(game->stalemate(false));   // black is stalemated
+    REQUIRE_FALSE(game->isAutomaticDraw());  // stalemate has priority
+    REQUIRE_FALSE(game->canClaimDraw());     // stalemate has priority
+}
+
 // ============================================================================
 // JSON Board State (toJson)
 // ============================================================================
@@ -2092,6 +2121,53 @@ TEST_CASE("ChessGame::fromFen: rejects side not to move in check", "[ChessGame][
 TEST_CASE("ChessGame::fromFen: rejects adjacent kings", "[ChessGame][FEN]") {
     auto game = ChessGame::fromFen("8/8/8/8/8/8/8/3Kk3 w - - 0 1");
     REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects too many white pieces", "[ChessGame][FEN]") {
+    // 17 white pieces: king + 8 pawns + 2 rooks + 2 knights + 2 bishops + queen + extra queen
+    auto game = ChessGame::fromFen("QRRNNBBQ/PPPPPPPP/8/8/8/8/1K6/7k w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects too many white pawns", "[ChessGame][FEN]") {
+    // 9 white pawns
+    auto game = ChessGame::fromFen("4K3/PPPPPPPP/P7/8/8/8/8/7k w - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects too many black pieces", "[ChessGame][FEN]") {
+    // 17 black pieces: 8 pawns + king + 2 rooks + 2 knights + 2 bishops + queen + extra queen
+    auto game = ChessGame::fromFen("7K/8/8/8/8/q7/pppppppp/qrrnnbbk b - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects too many black pawns", "[ChessGame][FEN]") {
+    auto game = ChessGame::fromFen("7K/8/8/8/8/p7/pppppppp/4k3 b - - 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects ep rank 3 when white to move", "[ChessGame][FEN]") {
+    // rank 3 ep target means white just double-pushed, so it must be black's turn
+    auto game = ChessGame::fromFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w - e3 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: rejects ep rank 6 when black to move", "[ChessGame][FEN]") {
+    // rank 6 ep target means black just double-pushed, so it must be white's turn
+    auto game = ChessGame::fromFen("rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR b - d6 0 1");
+    REQUIRE(game == nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: accepts ep rank 3 when black to move", "[ChessGame][FEN]") {
+    // rank 3 ep: white just double-pushed e2→e4, black to move
+    auto game = ChessGame::fromFen("rnbqkbnr/pppp1ppp/8/8/3Pp3/8/PPP1PPPP/RNBQKBNR b - d3 0 1");
+    REQUIRE(game != nullptr);
+}
+
+TEST_CASE("ChessGame::fromFen: accepts ep rank 6 when white to move", "[ChessGame][FEN]") {
+    // rank 6 ep: black just double-pushed d7→d5, white to move
+    auto game = ChessGame::fromFen("rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w - d6 0 1");
+    REQUIRE(game != nullptr);
 }
 
 // ============================================================================

--- a/chess/tests/chess_tests.cpp
+++ b/chess/tests/chess_tests.cpp
@@ -1730,6 +1730,80 @@ TEST_CASE("ChessGame: initial position is NOT insufficient material", "[ChessGam
 }
 
 // ============================================================================
+// Termination Priority (SPEC 4.5)
+// ============================================================================
+
+TEST_CASE("ChessGame: checkmate takes priority over 75-move automatic draw", "[ChessGame][Draw]") {
+    // Black king g8, black rook f8, white rook e1, white king a1. White to move.
+    // Re8# delivers back-rank checkmate (rook defended by... itself is the only
+    // piece on rank 8). Actually: Rxf8# — captures the rook, but that's a capture
+    // which resets halfmove. Use a different setup.
+    // White rook on a8, white king on a1, black king on c8, black pawn b7.
+    // Ra8 is already on a8 — move to c8? No, that's the king.
+    // Simpler: White queen h1, white bishop g2. Black king h8, black pawn g7.
+    // Qh7# doesn't work (pawn on g7 blocks?). Let me think...
+    // Back-rank with queen+bishop: Qh7, bishop on b1 defends h7 along diagonal.
+    // Actually just use queen + rook for a simple mating pattern.
+    // White: Kg1 (0,6), Qd1 (0,3), Rd7 (6,3). Black: Kg8 (7,6), Rf8 (7,5), pawn g7.
+    // Qd8 captures? No...
+    // Simplest: scholar's mate but with high halfmove clock.
+    // Kf3, Qf7, against Ke8 (and block all escapes). Qf7 is already check...
+    // Let me just use a 2-rook back rank mate.
+    // White: Ra1, Rb1, Ka3. Black: Ka8, pawns a7 b7. halfmove=149.
+    // Rb8# — rook to b8 (7,1). Black king a8 (7,0). a7 (6,0) has pawn.
+    // Is b8 defended? Ra1 on (0,0) doesn't defend b8. But wait — Rb8 is (7,1),
+    // and Ra1 is on a-file. Not defending. Hmm.
+    // Actually: Ra7, Rb1. Rb8#. Ra7 (6,0) blocks a7 escape.
+    // No — let me use: white rooks on a-file and b-file, high rank.
+    // Rb7 (6,1) and Ra1 (0,0), Kc1 (0,2). Black: Ka8 (7,0), pawn a6 (5,0).
+    // Rb8# — rook from b7 to b8. But black king can't go to a7 (blocked by...
+    // Rb7 is moving to b8, so b7 is vacated. King can go to a7 (6,0) if not attacked.
+    // Ra1 doesn't attack a7 directly. Hmm.
+    //
+    // I'll use a simpler approach: set the halfmove clock directly.
+    // Rook on e1, rook on d1, king a1. Black: king h8, pawns g7 h7 f7.
+    // Re8# — rook to e8 (7,4). Defended by Rd1? No. Let me just use a queen mate.
+    //
+    // Actually the simplest back rank mate: K on g1, R on d8, black K on g8 with
+    // pawns f7 g7 h7. Rd8 is already check. But I need to DELIVER it.
+    //
+    // Position: Kg1 (0,6), Rd1 (0,3). Black: Kg8 (7,6), Rf8 (7,5), pf7 (6,5), pg7 (6,6), ph7 (6,7).
+    // White plays Rd8 (0,3 -> 7,3). Check along rank 8? No, Rf8 blocks.
+    // Rxf8? That's a capture (resets clock).
+    //
+    // OK let me try: two white rooks, one delivers mate defended by the other.
+    // Rd1 (0,3), Re1 (0,4), Kg1 (0,6). Black: Kg8 (7,6), pf7, pg7, ph7.
+    // Rd8# — rook from d1 to d8 (7,3). Is black in check? Rd8 attacks along rank 8
+    // but Rf8... wait, there's no Rf8 here. Rank 8: only king on g8. So Rd8 checks
+    // the king on g8? d8 (7,3) to g8 (7,6): same rank, nothing between d8 and g8
+    // on rank 8 (e8, f8 are empty). Yes, check! King can go to: f8 (7,5) — is it
+    // attacked? Rd8 on d8 attacks rank 8 (including f8). h8 (7,7) — attacked by Rd8.
+    // Kh7 (6,7) — has own pawn. Kf7? (6,5) — own pawn. Can king capture Rd8? (7,3)
+    // That's too far. So: h8 attacked, f8 attacked, g7 own pawn, h7 own pawn, f7 own
+    // pawn. No legal moves → checkmate! And Re1 defends... actually Re1 doesn't need
+    // to defend Rd8 since the king can't reach d8 anyway. The point is all escape squares
+    // are blocked by own pawns or attacked by the rook.
+    auto game = ChessGame::fromFen("6k1/5ppp/8/8/8/8/8/3RR1K1 w - - 149 100");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->isAutomaticDraw());
+    // Rd8# — rook from d1 (0,3) to d8 (7,3)
+    REQUIRE(game->makeMove(ChessMove(0, 3, 7, 3)));
+    REQUIRE(game->checkmate(false));
+    REQUIRE_FALSE(game->isAutomaticDraw());
+    REQUIRE_FALSE(game->canClaimDraw());
+}
+
+TEST_CASE("ChessGame: checkmate takes priority over 50-move claimable draw", "[ChessGame][Draw]") {
+    // Same position, halfmove=99.
+    auto game = ChessGame::fromFen("6k1/5ppp/8/8/8/8/8/3RR1K1 w - - 99 100");
+    REQUIRE(game != nullptr);
+    REQUIRE_FALSE(game->canClaimDraw());
+    REQUIRE(game->makeMove(ChessMove(0, 3, 7, 3)));  // Rd8#
+    REQUIRE(game->checkmate(false));
+    REQUIRE_FALSE(game->canClaimDraw());
+}
+
+// ============================================================================
 // JSON Board State (toJson)
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- `canClaimDraw()` and `isAutomaticDraw()` now return false when checkmate has occurred, per SPEC 4.5
- Ensures correct game result in the edge case where checkmate coincides with a draw threshold (e.g., 150 halfmoves)

## Dependencies
- Depends on PR #31 (step 8h) and earlier PRs

## Test plan
- [x] 2 new tests: back-rank mate at 75-move and 50-move thresholds verifying draw methods return false
- [x] All 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)