### PR TITLE
Clarify that MCP tool errors must set isError: true

### DIFF
--- a/chess/SPEC.md
+++ b/chess/SPEC.md
@@ -1594,7 +1594,8 @@ Send a message to the opponent. **Not turn-gated.** Not available to spectators.
 
 ### 8.6 Error Format
 
-All errors are returned as MCP tool errors with a structured content object:
+All errors are returned as MCP tool errors — that is, the `CallToolResult` must have
+`isError` set to `true`, with the error details in a structured content object:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Clarifies Section 8.6 (Error Format) to explicitly reference `CallToolResult.isError`
- The existing language ("MCP tool errors") was ambiguous about whether the MCP protocol-level error signal should be used, or if returning an error-shaped dict as a normal result was sufficient
- One-line change: adds "the `CallToolResult` must have `isError` set to `true`"

## Test plan

N/A (spec text only)

Generated with [Claude Code](https://claude.com/claude-code)